### PR TITLE
[BPK-850] Use contenthash instead of hash in css-modules

### DIFF
--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -250,7 +250,7 @@ module.exports = {
             options: {
               importLoaders: 1,
               modules: !optInCssModules,
-              localIdentName: '[local]-[hash:base64:5]',
+              localIdentName: '[local]-[contenthash:base64:5]',
             },
           },
           {

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -261,7 +261,7 @@ module.exports = {
                     minimize: true,
                     sourceMap: true,
                     modules: !optInCssModules,
-                    localIdentName: '[local]-[hash:base64:5]',
+                    localIdentName: '[local]-[contenthash:base64:5]',
                   },
                 },
                 {


### PR DESCRIPTION
I think I may be missing something, is this all that's required? I read through the Slack thread mentioned in BPK-850 and this was all I could ascertain from it. Sorry for the delay, I've been reading a lot of Webpack 2 docs.
