### PR TITLE
adding saddlebag module regex to be compiled

### DIFF
--- a/packages/react-scripts/CHANGELOG.md
+++ b/packages/react-scripts/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 _Nothing yet..._
 
+## 5.0.4 - 2018-01-11
+### Added
+- Added `saddlebag-` prefix for saddlebag modules to be compiled by backpack-react-scripts
+
 ## 5.0.3 - 2017-12-21
 ### Fixed
 - Rebased onto `upstream/master` v1.0.17 (4b55193f0ad479f26b0f5e153bb4b152a1ee03e7)

--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -47,7 +47,8 @@ function getServedPath(appPackageJson) {
 }
 
 // Regex to match backpack node modules
-var backpackModulesRegex = /node_modules[\\/]bpk-/;
+const backpackModulesRegex = /node_modules[\\/]bpk-/;
+const saddlebagModulesRegex = /node_modules[\\/]saddlebag-/;
 
 // config after eject: we're in ./config/
 module.exports = {
@@ -64,6 +65,7 @@ module.exports = {
   publicUrl: getPublicUrl(resolveApp('package.json')),
   servedPath: getServedPath(resolveApp('package.json')),
   backpackModulesRegex: backpackModulesRegex,
+  saddlebagModulesRegex: saddlebagModulesRegex,
   appSsrJs: resolveApp('src/ssr.js'),
 };
 
@@ -89,6 +91,7 @@ module.exports = {
   ownPath: resolveOwn('.'),
   ownNodeModules: resolveOwn('node_modules'), // This is empty on npm 3
   backpackModulesRegex: backpackModulesRegex,
+  saddlebagModulesRegex: saddlebagModulesRegex,
   appSsrJs: resolveApp('src/ssr.js'),
 };
 
@@ -121,6 +124,7 @@ if (
     ownPath: resolveOwn('.'),
     ownNodeModules: resolveOwn('node_modules'),
     backpackModulesRegex: backpackModulesRegex,
+    saddlebagModulesRegex: saddlebagModulesRegex,
     appSsrJs: resolveOwn('template/src/ssr.js'),
   };
 }

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -202,6 +202,7 @@ module.exports = {
             include: [
               paths.appSrc,
               paths.backpackModulesRegex,
+              paths.saddlebagModulesRegex,
               ...customModuleRegexes,
             ],
             loader: require.resolve('babel-loader'),

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -211,6 +211,7 @@ module.exports = {
             include: [
               paths.appSrc,
               paths.backpackModulesRegex,
+              paths.saddlebagModulesRegex,
               ...customModuleRegexes,
             ],
             loader: require.resolve('babel-loader'),

--- a/packages/react-scripts/config/webpack.config.ssr.js
+++ b/packages/react-scripts/config/webpack.config.ssr.js
@@ -214,6 +214,7 @@ module.exports = {
             include: [
               paths.appSrc,
               paths.backpackModulesRegex,
+              paths.saddlebagModulesRegex,
               ...customModuleRegexes,
             ],
             loader: require.resolve('babel-loader'),


### PR DESCRIPTION
@matthewdavidson 

This is adding the `saddlebag-` prefix to be auto compiled by backpack-react-scripts since we're going to be publishing uncompiled versions of saddlebag.


cc @danrr 