### PR TITLE
[NOJIRA] - Use package.json name for jsonp function

### DIFF
--- a/packages/react-scripts/CHANGELOG.md
+++ b/packages/react-scripts/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## UNRELEASED
 
-_Nothing yet..._
+### Fixed
+- Use `package.json` name field as value for `output.jsonpFunction`, this is important for when multiple webpack runtimes from different compilation are used on the same page
 
 ## 5.0.6 - 2018-01-31
 ### Fixed

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -18,6 +18,7 @@ const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeM
 // const eslintFormatter = require('react-dev-utils/eslintFormatter');
 const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
 const sassFunctions = require('bpk-mixins/sass-functions');
+const camelCase = require('lodash/camelCase');
 const getClientEnvironment = require('./env');
 const getLocalIdent = require('./getLocalIdent');
 const paths = require('./paths');
@@ -92,6 +93,7 @@ module.exports = {
     // changing JS code would still trigger a refresh.
   ],
   output: {
+    jsonpFunction: camelCase(pkgJson.name + 'JsonpCallback'),
     // Add /* filename */ comments to generated require()s in the output.
     pathinfo: true,
     // This does not produce a real file. It's just the virtual path that is

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -20,6 +20,7 @@ const SWPrecacheWebpackPlugin = require('sw-precache-webpack-plugin');
 // const eslintFormatter = require('react-dev-utils/eslintFormatter');
 const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
 const sassFunctions = require('bpk-mixins/sass-functions');
+const camelCase = require('lodash/camelCase');
 const paths = require('./paths');
 const getClientEnvironment = require('./env');
 const getLocalIdent = require('./getLocalIdent');
@@ -98,6 +99,7 @@ module.exports = {
   // In production, we only want to load the polyfills and the app code.
   entry: [require.resolve('./polyfills'), paths.appIndexJs],
   output: {
+    jsonpFunction: camelCase(pkgJson.name + 'JsonpCallback'),
     // The build folder.
     path: paths.appBuild,
     // Generated JS file names (with nested folders).

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -42,6 +42,7 @@
     "html-webpack-plugin": "2.29.0",
     "identity-obj-proxy": "3.0.0",
     "jest": "20.0.4",
+    "lodash": "^4.17.5",
     "node-sass": "4.7.2",
     "object-assign": "4.1.1",
     "optimize-css-assets-webpack-plugin": "^3.2.0",

--- a/tasks/e2e-simple.sh
+++ b/tasks/e2e-simple.sh
@@ -322,9 +322,6 @@ verify_env_url
 # Test reliance on webpack internals
 verify_module_scope
 
-# Test ability to shrinkwrap
-npm shrinkwrap --save-dev
-
 # ******************************************************************************
 # Finally, let's check that everything still works after ejecting.
 # ******************************************************************************


### PR DESCRIPTION
See https://webpack.js.org/configuration/output/#output-jsonpfunction.

Also added lodash as a direct dependency. this will not affect install times as lodash was already a transient dependency:
```
├─┬ babel-core@6.26.0
│ ├─┬ babel-generator@6.26.1
│ │ └── lodash@4.17.5  deduped
│ ├─┬ babel-register@6.26.0
│ │ └── lodash@4.17.5  deduped
│ ├─┬ babel-template@6.26.0
│ │ └── lodash@4.17.5  deduped
│ ├─┬ babel-traverse@6.26.0
│ │ └── lodash@4.17.5  deduped
│ ├─┬ babel-types@6.26.0
│ │ └── lodash@4.17.5  deduped
│ └── lodash@4.17.5  deduped
├─┬ babel-eslint@8.2.2
│ ├─┬ @babel/traverse@7.0.0-beta.40
│ │ ├─┬ @babel/generator@7.0.0-beta.40
│ │ │ └── lodash@4.17.5  deduped
│ │ ├─┬ @babel/helper-function-name@7.0.0-beta.40
│ │ │ └─┬ @babel/template@7.0.0-beta.40
│ │ │   └── lodash@4.17.5  deduped
│ │ └── lodash@4.17.5  deduped
│ └─┬ @babel/types@7.0.0-beta.40
│   └── lodash@4.17.5  deduped
├─┬ babel-preset-react-app@3.1.0 -> /Users/matthewdavidson/projects/backpack-react-scripts/packages/babel-preset-react-app
│ ├─┬ babel-plugin-dynamic-import-node@1.1.0
│ │ ├─┬ babel-template@6.26.0
│ │ │ ├─┬ babel-traverse@6.26.0
│ │ │ │ └── lodash@4.17.5  deduped
│ │ │ └── lodash@4.17.5
│ │ └─┬ babel-types@6.26.0
│ │   └── lodash@4.17.5  deduped
│ └─┬ babel-preset-env@1.6.1
│   ├─┬ babel-plugin-transform-es2015-block-scoping@6.26.0
│   │ └── lodash@4.17.5  deduped
│   ├─┬ babel-plugin-transform-es2015-classes@6.24.1
│   │ └─┬ babel-helper-define-map@6.26.0
│   │   └── lodash@4.17.5  deduped
│   └─┬ babel-plugin-transform-es2015-sticky-regex@6.24.1
│     └─┬ babel-helper-regex@6.26.0
│       └── lodash@4.17.5  deduped
├─┬ eslint@4.13.1
│ ├─┬ inquirer@3.3.0
│ │ └── lodash@4.17.5  deduped
│ ├── lodash@4.17.5  deduped
│ └─┬ table@4.0.3
│   └── lodash@4.17.5  deduped
├─┬ extract-text-webpack-plugin@3.0.2
│ └─┬ async@2.6.0
│   └── lodash@4.17.5  deduped
├─┬ html-webpack-plugin@2.29.0
│ └── lodash@4.17.5  deduped
├── lodash@4.17.5
├─┬ node-sass@4.7.2
│ ├─┬ gaze@1.1.2
│ │ └─┬ globule@1.2.0
│ │   └── lodash@4.17.5  deduped
│ └─┬ sass-graph@2.2.4
│   └── lodash@4.17.5  deduped
├─┬ optimize-css-assets-webpack-plugin@3.2.0
│ └─┬ last-call-webpack-plugin@2.1.2
│   └── lodash@4.17.5  deduped
├─┬ react-dev-utils@4.2.1 -> /Users/matthewdavidson/projects/backpack-react-scripts/packages/react-dev-utils
│ └─┬ inquirer@3.3.0
│   └── lodash@4.17.5
├─┬ stylefmt@6.0.0
│ ├─┬ postcss-sorting@2.1.0
│ │ └── lodash@4.17.5  deduped
│ ├─┬ stylelint@7.13.0
│ │ ├─┬ colorguard@1.2.1
│ │ │ └─┬ postcss-reporter@1.4.1
│ │ │   └── lodash@4.17.5  deduped
│ │ ├─┬ doiuse@2.6.0
│ │ │ └── lodash@4.17.5  deduped
│ │ ├── lodash@4.17.5  deduped
│ │ └─┬ postcss-reporter@3.0.0
│ │   └── lodash@4.17.5  deduped
│ └─┬ stylelint-order@0.4.4
│   ├── lodash@4.17.5  deduped
│   └─┬ stylelint@7.13.0
│     ├── lodash@4.17.5  deduped
│     └─┬ postcss-reporter@3.0.0
│       └── lodash@4.17.5  deduped
├─┬ stylelint@8.4.0
│ ├── lodash@4.17.5  deduped
│ └─┬ postcss-reporter@5.0.0
│   └── lodash@4.17.5  deduped
├─┬ stylelint-config-skyscanner@1.0.1
│ ├─┬ stylelint-declaration-strict-value@1.0.4
│ │ └─┬ stylelint@7.13.0
│ │   ├── lodash@4.17.5  deduped
│ │   └─┬ postcss-reporter@3.0.0
│ │     └── lodash@4.17.5  deduped
│ ├─┬ stylelint-order@0.7.0
│ │ ├── lodash@4.17.5  deduped
│ │ └─┬ postcss-sorting@3.1.0
│ │   └── lodash@4.17.5  deduped
│ └─┬ stylelint-scss@2.4.0
│   └── lodash@4.17.5  deduped
├─┬ webpack-dev-server@2.9.4
│ └─┬ http-proxy-middleware@0.17.4
│   └── lodash@4.17.5  deduped
└─┬ webpack-manifest-plugin@1.3.2
  └── lodash@4.17.5  deduped
```