### PR TITLE
[BPK-1321] Add option to disable AMD parsing for specific modules

### DIFF
--- a/packages/react-scripts/CHANGELOG.md
+++ b/packages/react-scripts/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## UNRELEASED
 
-_Nothing yet..._
+### Added
+- New `amdExcludes` config in `package.json`. You can now disable AMD parsing for specific modules like so:
+
+```json
+  "backpack-react-scripts": {
+    "amdExcludes": [
+      "globalize"
+    ]
+  }
+```
 
 ## 5.0.7 - 2018-03-06
 ### Fixed

--- a/packages/react-scripts/config/webpack.config.dev.js
+++ b/packages/react-scripts/config/webpack.config.dev.js
@@ -178,7 +178,11 @@ module.exports = {
       //   include: paths.appSrc,
       // },
       {
-        test: /(^|\/)lodash(\/|\.|$)/,
+        test: new RegExp(
+          `(^|/)(${(bpkReactScriptsConfig.amdExcludes || [])
+            .concat('lodash')
+            .join('|')})(/|.|$)`
+        ),
         parser: {
           amd: false,
         },

--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -188,7 +188,11 @@ module.exports = {
       //   include: paths.appSrc,
       // },
       {
-        test: /(^|\/)lodash(\/|\.|$)/,
+        test: new RegExp(
+          `(^|/)(${(bpkReactScriptsConfig.amdExcludes || [])
+            .concat('lodash')
+            .join('|')})(/|.|$)`
+        ),
         parser: {
           amd: false,
         },

--- a/packages/react-scripts/config/webpack.config.ssr.js
+++ b/packages/react-scripts/config/webpack.config.ssr.js
@@ -189,7 +189,11 @@ module.exports = {
       //   include: paths.appSrc,
       // },
       {
-        test: /(^|\/)lodash(\/|\.|$)/,
+        test: new RegExp(
+          `(^|/)(${(bpkReactScriptsConfig.amdExcludes || [])
+            .concat('lodash')
+            .join('|')})(/|.|$)`
+        ),
         parser: {
           amd: false,
         },

--- a/packages/react-scripts/template/README.md
+++ b/packages/react-scripts/template/README.md
@@ -152,6 +152,31 @@ The above example assumes that the module you want to compile is named with the 
 with the name `some-module`. All entries in this array act as prefixes. It is used by all webpack configurations
 as well as the Jest configuration — if you want to avoid compiling a dependency in tests, you should mock it.
 
+## Disabling AMD parsing for certain modules
+
+If you need to disable AMD module support for whatever reason, you can add the following to your `package.json`:
+
+```json
+{
+  ...
+  "backpack-react-scripts": {
+    "amdExcludes": [
+      "globalize"
+    ]
+  }
+}
+```
+
+The above example disables AMD support for the `globalize` dependency and overcomes issues such as:
+
+```sh
+Failed to compile.
+./node_modules/globalize/dist/globalize.js
+Module not found: Can't resolve 'cldr' in './node_modules/globalize/dist'
+```
+
+> **Note:** `lodash` is disabled by default.
+
 ## CSS Modules
 
 All Sass files are by default treated as [CSS Modules](https://github.com/css-modules/css-modules). You can opt out of this behaviour using the following config option:


### PR DESCRIPTION
Adds new `amdExcludes` option for consumers:

```json
"backpack-react-scripts": {
  "amdExcludes": [
    "globalize"
  ]
}
```

`lodash` is still excluded by default.