### PR TITLE
Add Support for loadable/component

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -35,6 +35,7 @@ const typescriptFormatter = require('react-dev-utils/typescriptFormatter');
 const getCacheIdentifier = require('react-dev-utils/getCacheIdentifier');
 // @remove-on-eject-end
 
+const LoadablePlugin = require('@loadable/webpack-plugin');
 const sassFunctions = require('bpk-mixins/sass-functions');
 const camelCase = require('lodash/camelCase');
 const pkgJson = require(paths.appPackageJson);
@@ -421,6 +422,7 @@ module.exports = function(webpackEnv) {
                 ),
                 // @remove-on-eject-end
                 plugins: [
+                  "@loadable/babel-plugin",
                   [
                     require.resolve('babel-plugin-named-asset-import'),
                     {
@@ -594,6 +596,7 @@ module.exports = function(webpackEnv) {
       ],
     },
     plugins: [
+      new LoadablePlugin(),
       // Generates an `index.html` file with the <script> injected.
       new HtmlWebpackPlugin(
         Object.assign(

--- a/packages/react-scripts/config/webpack.config.ssr.js
+++ b/packages/react-scripts/config/webpack.config.ssr.js
@@ -35,6 +35,7 @@ const typescriptFormatter = require('react-dev-utils/typescriptFormatter');
 const getCacheIdentifier = require('react-dev-utils/getCacheIdentifier');
 // @remove-on-eject-end
 
+const LoadablePlugin = require('@loadable/webpack-plugin');
 const sassFunctions = require('bpk-mixins/sass-functions');
 // const camelCase = require('lodash/camelCase');
 const pkgJson = require(paths.appPackageJson);
@@ -436,6 +437,7 @@ module.exports = function(webpackEnv) {
                 ),
                 // @remove-on-eject-end
                 plugins: [
+                  "@loadable/babel-plugin",
                   [
                     require.resolve('babel-plugin-named-asset-import'),
                     {
@@ -609,6 +611,7 @@ module.exports = function(webpackEnv) {
       ],
     },
     plugins: [
+      new LoadablePlugin(),
       // Generates an `index.html` file with the <script> injected.
       // new HtmlWebpackPlugin(
       //   Object.assign(

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -22,6 +22,8 @@
   "types": "./lib/react-app.d.ts",
   "dependencies": {
     "@babel/core": "7.2.2",
+    "@loadable/babel-plugin": "^5.6.0",
+    "@loadable/webpack-plugin": "^5.5.0",
     "@svgr/webpack": "2.4.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "23.6.0",


### PR DESCRIPTION
Add support for server rendered async components into backpack-react-scripts. This allows any users of backpack-react-scripts to easily add code splitting by route to their projects so that their users only download the necessary JS for the page they are currently on.

## How to Include SSR Async Components in Your Project

In order to use async components and have them server side rendered, you will need to add the following code to any project. More detailed documentation can be found here https://www.smooth-code.com/open-source/loadable-components/docs/server-side-rendering/

1. Install `@loadable/component` and `@loadable/server` in the client package these both must be in client package and not in the server package as loadable/component and and loadable/server use a shared React Context to communicate.

2. Make your component async by replacing the import statement with this line
```
const Component = loadable(() => import('./Component'));
```
3. Add a ChunkExtractor and ChunkExtractorManager to your static routed app
```
const StaticRoutedApp = ({ url, props, statsFile, extractorCallback }) => {
  const extractor = new ChunkExtractor({ statsFile });
  extractorCallback(extractor);

  return (
    <ChunkExtractorManager extractor={extractor}>
      <StaticRouter location={url} context={{}}>
        <App {...props} />
      </StaticRouter>
    </ChunkExtractorManager>
  );
};
```
4. Extract the html, styles and script tags from the server render
```
const statsFile = path.resolve('client/build/loadable-stats.json');

const renderReactApp = ({ url, props }) => {
  let extractor;

  const reactAppRoot = React.createElement(StaticRoutedApp, {
    url,
    props,
    statsFile,
    extractorCallback: e => {
      extractor = e;
    },
  });
  const html = ReactDOMServer.renderToString(reactAppRoot);
  const styles = extractor.getStyleTags();
  const scripts = extractor.getScriptTags();
  return { html, styles, scripts };
};
```
5. Include these in your html that you send down to the client

Under the hood, the webpack plugin is generating a loadable-stats.json which describes your module structure and the babel plugin is replacing the call to `loadable` with an output that can use the loadable-stats to import your async component. More detail can be found here https://www.smooth-code.com/open-source/loadable-components/docs/babel-plugin/.

## Current Open Questions
1. Should this functionality be behind some kind of config flag or enabled by default? The current implementation is enabled by default
2. These change have been verified in our local project node_modules but there could be better ways to verify that these exact changes when applied output the desired result. If there are any concerns please flag these up and I will do more verification.

