### PR TITLE
Add `vendorsChunkRegex`

### DIFF
--- a/packages/react-scripts/CHANGELOG.md
+++ b/packages/react-scripts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `backpack-react-scripts` Change Log
 
+## 7.0.3 (November 18, 2019)
+
+- Add the ability to split vendor chunks using `vendorChunkRegex`. Anything that matches the regex will be put in the vendors chunk. [See PR from banana project](https://github.skyscannertools.net/dingo/banana/blob/2c5bf3f89bc0d1fec29e7fae27dd5988e99dedec/packages/webapp/package.json#L151)
+
 ## 7.0.1 - 2019-09-18
 
 ### Fixed

--- a/packages/react-scripts/README.md
+++ b/packages/react-scripts/README.md
@@ -23,6 +23,7 @@ npm start
   - `crossOriginLoading`: Modify the default behaviour, see [docs](https://webpack.js.org/configuration/output/#output-crossoriginloading).
   - `babelIncludePrefixes`: An array of module name prefixes to opt into babel compilation. Includes `["bpk-", "saddlebag-"]` by default.
   - `enableAutomaticChunking`: Boolean, opt in to automatic chunking of vendor, common and app code.
+  - `overrideChunkingConfig`: Object, config to override specific chunking groups. See `cacheGroups` in webpack docs. e.g. Allows regex test for chunking certain packages
   - `amdExcludes`: Array of module names to exclude from AMD parsing. Incldues `["lodash"]` by default.
   - `externals`: exposing the Webpack config to modify externals, see [docs](https://webpack.js.org/configuration/externals/).
   - `ssrExternals`: Similar to above, but for `ssr.js` only.

--- a/packages/react-scripts/README.md
+++ b/packages/react-scripts/README.md
@@ -23,7 +23,7 @@ npm start
   - `crossOriginLoading`: Modify the default behaviour, see [docs](https://webpack.js.org/configuration/output/#output-crossoriginloading).
   - `babelIncludePrefixes`: An array of module name prefixes to opt into babel compilation. Includes `["bpk-", "saddlebag-"]` by default.
   - `enableAutomaticChunking`: Boolean, opt in to automatic chunking of vendor, common and app code.
-  - `overrideChunkingConfig`: Object, config to override specific chunking groups. See `cacheGroups` in webpack docs. e.g. Allows regex test for chunking certain packages
+  - `vendorsChunkRegex`: String, Regex for picking what goes into the `vendors` chunk. See `cacheGroups` in webpack docs. Dependent on `enableAutomaticChunking` being enabled
   - `amdExcludes`: Array of module names to exclude from AMD parsing. Incldues `["lodash"]` by default.
   - `externals`: exposing the Webpack config to modify externals, see [docs](https://webpack.js.org/configuration/externals/).
   - `ssrExternals`: Similar to above, but for `ssr.js` only.
@@ -37,7 +37,7 @@ npm start
    npm run publish -- --scope backpack-react-scripts
    ```
 
-1. You will be prompted to select a new semver version (MAJOR, MINOR, PATCH). Use the [CHANGELOG.md](./CHANGELOG.md) to decide on the nature of the changes since the last release.
+2. You will be prompted to select a new semver version (MAJOR, MINOR, PATCH). Use the [CHANGELOG.md](./CHANGELOG.md) to decide on the nature of the changes since the last release.
 
    - If you want to be extra careful, you can publish a prerelease by running this instead:
 
@@ -45,7 +45,7 @@ npm start
    npm run publish -- --scope backpack-react-scripts --canary
    ```
 
-1. Update the [CHANGELOG.md](./CHANGELOG.md) with the new version, taking care to follow the format of previous releases.
+3. Update the [CHANGELOG.md](./CHANGELOG.md) with the new version, taking care to follow the format of previous releases.
 
 ## Keeping this fork updated
 

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -280,8 +280,12 @@ module.exports = function(webpackEnv) {
       splitChunks: bpkReactScriptsConfig.enableAutomaticChunking
         ? {
             chunks: 'all',
-            name: true,
-            cacheConfig: bpkReactScriptsConfig.overrideChunkingConfig || {},
+            name: false,
+            cacheGroups: bpkReactScriptsConfig.vendorsChunkRegex ? {
+              vendors: {
+                test: new RegExp(bpkReactScriptsConfig.vendorsChunkRegex),
+              },
+            } : {},
           }
         : {},
       // Keep the runtime chunk seperated to enable long term caching

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -278,7 +278,11 @@ module.exports = function(webpackEnv) {
       //   name: false,
       // },
       splitChunks: bpkReactScriptsConfig.enableAutomaticChunking
-        ? { chunks: 'all', name: true }
+        ? {
+            chunks: 'all',
+            name: true,
+            cacheConfig: bpkReactScriptsConfig.overrideChunkingConfig || {},
+          }
         : {},
       // Keep the runtime chunk seperated to enable long term caching
       // https://twitter.com/wSokra/status/969679223278505985

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -280,7 +280,7 @@ module.exports = function(webpackEnv) {
       splitChunks: bpkReactScriptsConfig.enableAutomaticChunking
         ? {
             chunks: 'all',
-            name: isEnvDevelopment,
+            name: false,
             cacheGroups: bpkReactScriptsConfig.vendorsChunkRegex ? {
               vendors: {
                 test: new RegExp(bpkReactScriptsConfig.vendorsChunkRegex),

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -280,7 +280,7 @@ module.exports = function(webpackEnv) {
       splitChunks: bpkReactScriptsConfig.enableAutomaticChunking
         ? {
             chunks: 'all',
-            name: false,
+            name: isEnvDevelopment,
             cacheGroups: bpkReactScriptsConfig.vendorsChunkRegex ? {
               vendors: {
                 test: new RegExp(bpkReactScriptsConfig.vendorsChunkRegex),

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backpack-react-scripts",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "description": "Backpack configuration and scripts for Create React App.",
   "repository": "Skyscanner/backpack-react-scripts",
   "license": "MIT",


### PR DESCRIPTION
Add the ability to configure the contents of `vendors` chunk in when `enableAutomaticChunking` is enabled.

You can now use `vendorsChunkRegex` to customise the behaviour which would otherwise be `/[\\/]node_modules[\\/]/`