### PR TITLE
[NO JIRA]: Fixed usage script

### DIFF
--- a/packages/react-scripts/README.md
+++ b/packages/react-scripts/README.md
@@ -4,7 +4,7 @@ This package is a fork of [Create React App](https://github.com/facebookincubato
 `react-scripts` package). It's intended to be used in conjuction with `create-react-app` like so:
 
 ```sh
-npx create-react-app my-app --scripts-version=backpack-react-scripts
+npx create-react-app@2.1.2 my-app --scripts-version=backpack-react-scripts
 
 # start your app development like you normally would with `create-react-app`
 cd my-app


### PR DESCRIPTION
This PR fixes the instructions on how to use BRS to specify the current supported BRS version.

Before when we were just specifying `npx create-react-app my-app --scripts-version=backpack-react-scripts` unless you had a specific CRA version installed locally it would pull the latest CRA from npm.

In the latest version there was templating added which BRS not yet supports so when running the regular script without specifying a version it would grab the latest. 3.3.0 and error due to this new feature, which would just output a folder with node_modules and a package.json which is not the expected output.