### PR TITLE
Upgrade terser-webpack-plugin to v2.3.4

### DIFF
--- a/packages/react-error-overlay/package.json
+++ b/packages/react-error-overlay/package.json
@@ -60,7 +60,7 @@
     "rimraf": "^2.6.2",
     "settle-promise": "1.0.0",
     "source-map": "0.5.6",
-    "terser-webpack-plugin": "1.2.1",
+    "terser-webpack-plugin": "2.3.4",
     "webpack": "^4.8.1"
   },
   "jest": {

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -57,7 +57,7 @@
     "resolve": "1.9.0",
     "sass-loader": "7.1.0",
     "style-loader": "0.23.1",
-    "terser-webpack-plugin": "1.2.1",
+    "terser-webpack-plugin": "2.3.4",
     "url-loader": "1.1.2",
     "webpack": "4.28.3",
     "webpack-dev-server": "3.1.14",


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
Upgrades terser-webpack-plugin to the latest version at time of writing, 2.3.4. 
This was done because the currently used version of terser-webpack-plugin depends on an old version of serialize-javascript which has been found to contain an XSS vulnerability (see Snyk). The latest version uses a newer serialize-javascript, which does not have the vulnerability.