### PR TITLE
[BPK-3997]: Make SRI optional

### DIFF
--- a/packages/react-scripts/README.md
+++ b/packages/react-scripts/README.md
@@ -30,6 +30,8 @@ npm start
   - `externals`: exposing the Webpack config to modify externals, see [docs](https://webpack.js.org/configuration/externals/).
   - `ssrExternals`: Similar to above, but for `ssr.js` only.
   - `cssModules`: Boolean, true by default.
+  - `sriEnabled`: Sets if SRI is to be used during build to add integrity hash for files, see [docs](https://github.com/waysact/webpack-subresource-integrity/blob/master/README.md).
+    - **Note** if this is enabled, `crossOriginLoading` value is overriden with `anonymous` in order for it to output with the integrity value.
 
 ## Releasing a new version of `backpack-react-scripts`
 

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -49,8 +49,8 @@ const customModuleRegexes = bpkReactScriptsConfig.babelIncludePrefixes
     )
   : [];
 const cssModulesEnabled = bpkReactScriptsConfig.cssModules !== false;
-const crossOriginLoading =
-  bpkReactScriptsConfig.crossOriginLoading || 'anonymous';
+const crossOriginLoading = bpkReactScriptsConfig.crossOriginLoading || false;
+const sriEnabled = bpkReactScriptsConfig.sriEnabled || false;
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
 const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';
@@ -193,7 +193,7 @@ module.exports = function(webpackEnv) {
       // changing JS code would still trigger a refresh.
     ].filter(Boolean),
     output: {
-      crossOriginLoading,
+      crossOriginLoading: sriEnabled ? 'anonymous' : crossOriginLoading,
       // The build folder.
       path: isEnvProduction ? paths.appBuild : undefined,
       // Add /* filename */ comments to generated require()s in the output.
@@ -760,10 +760,11 @@ module.exports = function(webpackEnv) {
       // https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
       // This is a security feature that enables browsers to verify that resources
       // they fetch (for example, from a CDN) are delivered without unexpected manipulation.
-      new SubresourceIntegrityPlugin({
-        enabled: true,
-        hashFuncNames: ['sha384'],
-      }),
+      sriEnabled &&
+        new SubresourceIntegrityPlugin({
+          enabled: true,
+          hashFuncNames: ['sha384'],
+        }),
       // Moment.js is an extremely popular library that bundles large locale files
       // by default due to how webpack interprets its code. This is a practical
       // solution that requires the user to opt into importing specific locales.


### PR DESCRIPTION
This makes #79 - Enabled SRI an opt in functionality where a user will set `sriEnabled` in the BRS config.

Doing this overrides any value set by `crossOriginLoading` when this is enabled