### PR TITLE
Update create-react-app@4.0.1 README.md

### DIFF
--- a/packages/react-scripts/README.md
+++ b/packages/react-scripts/README.md
@@ -1,12 +1,12 @@
 # backpack-react-scripts
 
-### **Important:** The currently supported version of **CRA** by `backpack-react-scripts` is up to `v4.0.0`. Versions above this will not work.
+### **Important:** The currently supported version of **CRA** by `backpack-react-scripts` is up to `v4.0.1`. Versions above this will not work.
 
 This package is a fork of [Create React App](https://github.com/facebookincubator/create-react-app) (specifically the
 `react-scripts` package). It's intended to be used in conjuction with `create-react-app` like so:
 
 ```sh
-npx create-react-app@4.0.0 my-app --scripts-version=@skyscanner/backpack-react-scripts --template @skyscanner/backpack --use-npm
+npx create-react-app@4.0.1 my-app --scripts-version=@skyscanner/backpack-react-scripts --template @skyscanner/backpack --use-npm
 
 # start your app development like you normally would with `create-react-app`
 cd my-app


### PR DESCRIPTION
Currently the latest version available is `4.0.1`

By running `npx create-react-app@4.0.0 my-app --scripts-version=@skyscanner/backpack-react-scripts --template @skyscanner/backpack --use-npm` the output would be:
```
npx: installed 92 in 8.388s

You are running `create-react-app` 4.0.0, which is behind the latest release (4.0.1).

We no longer support global installation of Create React App.

Please remove any global installs with one of the following commands:
- npm uninstall -g create-react-app
- yarn global remove create-react-app

The latest instructions for creating a new app can be found here:
https://create-react-app.dev/docs/getting-started/
```

Using `npx create-react-app@4.0.1 ...` fixes it 😉 

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
