### PR TITLE
[VUL-813] Update start-ssr script to run web & ssr builds

### DIFF
--- a/packages/react-scripts/config/webpack.config.ssr.js
+++ b/packages/react-scripts/config/webpack.config.ssr.js
@@ -710,6 +710,9 @@ module.exports = function (webpackEnv) {
                 sourceMap: isEnvProduction
                   ? shouldUseSourceMap
                   : isEnvDevelopment,
+                modules: {
+                  exportOnlyLocals: true,
+                },
               }),
               // Don't consider CSS imports dead code even if the
               // containing package claims to have no side effects.
@@ -740,6 +743,7 @@ module.exports = function (webpackEnv) {
                   : isEnvDevelopment,
                 modules: {
                   getLocalIdent: getCSSModuleLocalIdent,
+                  exportOnlyLocals: true,
                 },
               }),
             },
@@ -758,6 +762,9 @@ module.exports = function (webpackEnv) {
                   sourceMap: isEnvProduction
                     ? shouldUseSourceMap
                     : isEnvDevelopment,
+                  modules: {
+                    exportOnlyLocals: true,
+                  },
                 },
                 'sass-loader',
                 {
@@ -794,6 +801,7 @@ module.exports = function (webpackEnv) {
                     : isEnvDevelopment,
                   modules: {
                     getLocalIdent: getCSSModuleLocalIdent,
+                    exportOnlyLocals: true,
                   },
                 },
                 'sass-loader',

--- a/packages/react-scripts/config/webpack.config.ssr.js
+++ b/packages/react-scripts/config/webpack.config.ssr.js
@@ -8,6 +8,10 @@
 // @remove-on-eject-end
 'use strict';
 
+// We need to disable React Refresh, because we don't use a DevServer for SSR
+// builds. The least intrusive way to do that is to use CRA's FAST_REFRESH option.
+process.env.FAST_REFRESH = 'false';
+
 const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
@@ -168,7 +172,7 @@ module.exports = function (webpackEnv) {
         // So adding the option here in replacement as per
         // https://github.com/webpack-contrib/css-loader/tree/v3.4.2#onlylocals
         loader: require.resolve('css-loader'),
-        options: { ...cssOptions, onlyLocals: true },
+        options: cssOptions,
       },
       {
         // Options for PostCSS as we reference these options twice

--- a/packages/react-scripts/config/webpack.config.ssr.js
+++ b/packages/react-scripts/config/webpack.config.ssr.js
@@ -172,7 +172,7 @@ module.exports = function (webpackEnv) {
         // So adding the option here in replacement as per
         // https://github.com/webpack-contrib/css-loader/tree/v3.4.2#onlylocals
         loader: require.resolve('css-loader'),
-        options: cssOptions,
+        options: { ...cssOptions, onlyLocals: true },
       },
       {
         // Options for PostCSS as we reference these options twice

--- a/packages/react-scripts/config/webpack.config.ssr.js
+++ b/packages/react-scripts/config/webpack.config.ssr.js
@@ -168,11 +168,8 @@ module.exports = function (webpackEnv) {
       //   },
       // },
       {
-        // In v3.0.0 css-loader/locals was removed in favour of onlyLocals option
-        // So adding the option here in replacement as per
-        // https://github.com/webpack-contrib/css-loader/tree/v3.4.2#onlylocals
         loader: require.resolve('css-loader'),
-        options: { ...cssOptions, onlyLocals: true },
+        options: cssOptions,
       },
       {
         // Options for PostCSS as we reference these options twice

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyscanner/backpack-react-scripts",
-  "version": "9.2.0-alpha.2c740a6a",
+  "version": "9.2.0-alpha.8191c3",
   "description": "Backpack configuration and scripts for Create React App.",
   "repository": {
     "type": "git",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyscanner/backpack-react-scripts",
-  "version": "9.2.0-alpha.8191c3",
+  "version": "9.2.0-alpha.df35bf6",
   "description": "Backpack configuration and scripts for Create React App.",
   "repository": {
     "type": "git",

--- a/packages/react-scripts/scripts/start-ssr.js
+++ b/packages/react-scripts/scripts/start-ssr.js
@@ -216,15 +216,20 @@ checkBrowsers(paths.appPath, isInteractive)
       color: 'bgMagenta',
     });
     ui.register(ssrUi);
-    ssr.on('error', error => console.error(error));
-    // @brs-begin
+
+    ssr.on('exit', code => {
+      ssrUi.log(chalk.red(`Fatal! Process ended with code ${code}`));
+      devServer.close();
+      process.exit();
+    });
+    // @brs-end
 
     ['SIGINT', 'SIGTERM'].forEach(function (sig) {
       process.on(sig, function () {
         devServer.close();
-        process.exit();
         // @brs-begin
         ssr.kill();
+        process.exit();
         // @brs-end
       });
     });
@@ -233,9 +238,9 @@ checkBrowsers(paths.appPath, isInteractive)
       // Gracefully exit when stdin ends
       process.stdin.on('end', function () {
         devServer.close();
-        process.exit();
         // @brs-begin
         ssr.kill();
+        process.exit();
         // @brs-end
       });
     }

--- a/packages/react-scripts/scripts/start-ssr.js
+++ b/packages/react-scripts/scripts/start-ssr.js
@@ -6,6 +6,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 // @remove-on-eject-end
+
+// @brs-begin
+/**
+ * This script is a copy of start.js with an SSR compiler included. It runs
+ * both the `web` and `ssr` builds at once, serving the `web` build exactly as
+ * start does (with a WebpackDevServer), and spawning the `ssr` build in a
+ * forked process.
+ */
+// @brs-end
+
 'use strict';
 
 // Do this as the first thing so that any code reading it knows the right env.
@@ -15,7 +25,7 @@ process.env.NODE_ENV = 'development';
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.
-process.on('unhandledRejection', (err) => {
+process.on('unhandledRejection', err => {
   throw err;
 });
 
@@ -32,59 +42,207 @@ verifyTypeScriptSetup();
 // @remove-on-eject-end
 
 const fs = require('fs');
+const chalk = require('react-dev-utils/chalk');
 const webpack = require('webpack');
+const WebpackDevServer = require('webpack-dev-server');
+const clearConsole = require('react-dev-utils/clearConsole');
+const checkRequiredFiles = require('react-dev-utils/checkRequiredFiles');
 const {
-  createCompiler,
+  choosePort,
+  prepareProxy,
   prepareUrls,
 } = require('react-dev-utils/WebpackDevServerUtils');
+const openBrowser = require('react-dev-utils/openBrowser');
+const semver = require('semver');
 const paths = require('../config/paths');
-const configFactory = require('../config/webpack.config.ssr');
+const configFactory = require('../config/webpack.config');
+const createDevServerConfig = require('../config/webpackDevServer.config');
+const getClientEnvironment = require('../config/env');
+const react = require(require.resolve('react', { paths: [paths.appPath] }));
 
+const env = getClientEnvironment(paths.publicUrlOrPath.slice(0, -1));
+
+// @brs-begin
 const statusFile = require('./utils/statusFile');
+const { createCustomCompiler } = require('./utils/customWebpackUtils');
+const {
+  MultiCompilerUi,
+  WebCompilerUi,
+  ProcessMessageCompilerUi,
+} = require('./utils/MultiCompilerUi');
+// @brs-end
 
 const useYarn = fs.existsSync(paths.yarnLockFile);
+const isInteractive = process.stdout.isTTY;
 
-const port = parseInt(process.env.PORT, 10) || 3000;
+// Warn and crash if required files are missing
+if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
+  process.exit(1);
+}
+
+// Tools like Cloud9 rely on this.
+const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 3000;
 const HOST = process.env.HOST || '0.0.0.0';
 
-const config = configFactory('development');
-const protocol = process.env.HTTPS === 'true' ? 'https' : 'http';
-const appName = require(paths.appPackageJson).name;
+if (process.env.HOST) {
+  console.log(
+    chalk.cyan(
+      `Attempting to bind to HOST environment variable: ${chalk.yellow(
+        chalk.bold(process.env.HOST)
+      )}`
+    )
+  );
+  console.log(
+    `If this was unintentional, check that you haven't mistakenly set it in your shell.`
+  );
+  console.log(
+    `Learn more here: ${chalk.yellow('https://cra.link/advanced-config')}`
+  );
+  console.log();
+}
 
-const useTypeScript = fs.existsSync(paths.appTsConfig);
-const tscCompileOnError = process.env.TSC_COMPILE_ON_ERROR === 'true';
-const urls = prepareUrls(
-  protocol,
-  HOST,
-  port,
-  paths.publicUrlOrPath.slice(0, -1)
-);
+// @brs-begin
+const ui = new MultiCompilerUi();
+// @brs-end
 
-const createCompilerOpts = ;
-
-const compiler = createCompiler({
-  appName,
-  config,
-  devSocket: undefined,
-  urls,
-  useYarn,
-  useTypeScript,
-  tscCompileOnError,
-  webpack,
-});
-
-statusFile.init(compiler, paths.appBuildSsr);
-
-compiler.watch(
-  {
-    ignored: ['node_modules'],
-  },
-  (err) => {
-    if (err) {
-      console.log(err.message || err);
-      process.exit(1);
+// We require that you explicitly set browsers and do not fall back to
+// browserslist defaults.
+const { checkBrowsers } = require('react-dev-utils/browsersHelper');
+checkBrowsers(paths.appPath, isInteractive)
+  .then(() => {
+    // We attempt to use the default port but if it is busy, we offer the user to
+    // run on a different port. `choosePort()` Promise resolves to the next free port.
+    return choosePort(HOST, DEFAULT_PORT);
+  })
+  .then(port => {
+    if (port == null) {
+      // We have not found a port.
+      return;
     }
 
-    statusFile.done(paths.appBuildSsr);
-  }
-);
+    const config = configFactory('development');
+    const protocol = process.env.HTTPS === 'true' ? 'https' : 'http';
+    const appName = require(paths.appPackageJson).name;
+
+    const useTypeScript = fs.existsSync(paths.appTsConfig);
+    const tscCompileOnError = process.env.TSC_COMPILE_ON_ERROR === 'true';
+    const urls = prepareUrls(
+      protocol,
+      HOST,
+      port,
+      paths.publicUrlOrPath.slice(0, -1)
+    );
+    const devSocket = {
+      warnings: warnings =>
+        devServer.sockWrite(devServer.sockets, 'warnings', warnings),
+      errors: errors =>
+        devServer.sockWrite(devServer.sockets, 'errors', errors),
+    };
+
+    // @brs-begin
+    const webUi = new WebCompilerUi(
+      'web',
+      { color: 'bgBlue' },
+      { appName, urls, useYarn }
+    );
+    ui.register(webUi);
+
+    const compiler = createCustomCompiler(webUi, {
+      appName,
+      config,
+      devSocket,
+      urls,
+      useYarn,
+      useTypeScript,
+      tscCompileOnError,
+      webpack,
+    });
+
+    statusFile.init(compiler, paths.appBuildWeb);
+    // @brs-end
+
+    // Load proxy config
+    const proxySetting = require(paths.appPackageJson).proxy;
+    const proxyConfig = prepareProxy(
+      proxySetting,
+      paths.appPublic,
+      paths.publicUrlOrPath
+    );
+    // Serve webpack assets generated by the compiler over a web server.
+    const serverConfig = createDevServerConfig(
+      proxyConfig,
+      urls.lanUrlForConfig
+    );
+
+    serverConfig.writeToDisk = filePath => {
+      return /loadable-stats\.json/.test(filePath);
+    };
+
+    const devServer = new WebpackDevServer(compiler, serverConfig);
+    // Launch WebpackDevServer.
+    devServer.listen(port, HOST, err => {
+      if (err) {
+        return console.log(err);
+      }
+      if (isInteractive) {
+        clearConsole();
+      }
+
+      if (env.raw.FAST_REFRESH && semver.lt(react.version, '16.10.0')) {
+        console.log(
+          chalk.yellow(
+            `Fast Refresh requires React 16.10 or higher. You are using React ${react.version}.`
+          )
+        );
+      }
+
+      console.log(chalk.cyan('Starting the development server...\n'));
+      openBrowser(urls.localUrlForBrowser);
+
+      // @brs-begin
+      // This method will clear the console, so we put it after CRA has logged the messages above.
+      ui.start();
+      // @brs-end
+    });
+
+    // @brs-begin
+    const { fork } = require('child_process');
+    const { join } = require('path');
+
+    // We do this in a background process for performance - multicore, yo.
+    const ssr = fork(join(__dirname, './utils/forkSsr'));
+
+    const ssrUi = new ProcessMessageCompilerUi(ssr, 'ssr', {
+      color: 'bgMagenta',
+    });
+    ui.register(ssrUi);
+    ssr.on('error', error => console.error(error));
+    // @brs-begin
+
+    ['SIGINT', 'SIGTERM'].forEach(function (sig) {
+      process.on(sig, function () {
+        devServer.close();
+        process.exit();
+        // @brs-begin
+        ssr.kill();
+        // @brs-end
+      });
+    });
+
+    if (process.env.CI !== 'true') {
+      // Gracefully exit when stdin ends
+      process.stdin.on('end', function () {
+        devServer.close();
+        process.exit();
+        // @brs-begin
+        ssr.kill();
+        // @brs-end
+      });
+    }
+  })
+  .catch(err => {
+    if (err && err.message) {
+      console.log(err.message);
+    }
+    process.exit(1);
+  });

--- a/packages/react-scripts/scripts/utils/MultiCompilerUi.js
+++ b/packages/react-scripts/scripts/utils/MultiCompilerUi.js
@@ -205,7 +205,7 @@ class WebCompilerUi extends CompilerUi {
   }
 
   /**
-   * This function is taken directory from react-dev-utils/WebpackDevServerUtils.js,
+   * This function is taken directly from react-dev-utils/WebpackDevServerUtils.js,
    * with all `console.log` references replaced with `this.log`.
    */
   printInstructions() {

--- a/packages/react-scripts/scripts/utils/MultiCompilerUi.js
+++ b/packages/react-scripts/scripts/utils/MultiCompilerUi.js
@@ -14,6 +14,8 @@ const isInteractive = process.stdout.isTTY;
  *
  * Several varieties of CompilerUi are provided for different use cases.
  *
+ * See the start-ssr.js script for an example of it in action.
+ *
  * @example
  * const ui = new MultiCompilerUi();
  *
@@ -34,7 +36,15 @@ const isInteractive = process.stdout.isTTY;
  * // No output is generated until start() is called.
  * ui.start();
  *
- * See the start-ssr.js script for an example of it in action.
+ * // The log() method appends output, the clear() method clears it.
+ * simpleUi.log('Some info');
+ * simpleUi.log('More info');
+ * simpleUi.clear();
+ * simpleUi.log('Fresh info');
+ *
+ * // CompilerUi output is independent
+ * customUi.log('woah');
+ * customUi.clear();
  */
 class MultiCompilerUi {
   constructor() {
@@ -79,7 +89,12 @@ class MultiCompilerUi {
 
   clear(name) {
     this.output[name] = '';
-    this.render();
+
+    // Don't render in non-interactive mode, so that we don't spam the console
+    // with empty messages.
+    if (isInteractive) {
+      this.render();
+    }
   }
 
   start() {

--- a/packages/react-scripts/scripts/utils/MultiCompilerUi.js
+++ b/packages/react-scripts/scripts/utils/MultiCompilerUi.js
@@ -1,0 +1,291 @@
+const clearConsole = require('react-dev-utils/clearConsole');
+const chalk = require('chalk');
+
+const isInteractive = process.stdout.isTTY;
+
+/**
+ * This class manages the output of multiple Webpack compilers to render a
+ * rudimentary Terminal UI. It's designed to be used with
+ * utils/customWebpackUtils.js#createCustomCompiler.
+ *
+ * Each Webpack compiler is represented by a CompilerUi instance, which can be
+ * extended. Each CompilerUi instance has a name which is used to track its
+ * output and label it in the UI.
+ *
+ * Several varieties of CompilerUi are provided for different use cases.
+ *
+ * @example
+ * const ui = new MultiCompilerUi();
+ *
+ * // The create() method returns a basic, pre-registered CompilerUi
+ * const simpleUi = ui.create('simple', { color: 'blue' });
+ *
+ * // You can extend CompilerUi to control behaviour
+ * class MyCustomUi extends CompilerUi {
+ *   log(message = '') {
+ *     // Customise the log method
+ *   }
+ * }
+ *
+ * // CompilerUi instances must be registered before they're used.
+ * const customUi = new MyCustomUi('custom', { color: 'green' });
+ * ui.register(customUi);
+ *
+ * // No output is generated until start() is called.
+ * ui.start();
+ *
+ * See the start-ssr.js script for an example of it in action.
+ */
+class MultiCompilerUi {
+  constructor() {
+    this.output = {};
+    this.compilers = {};
+  }
+
+  /**
+   * Create and register a basic CompilerUi.
+   *
+   * @param {string} name - Used to label the compiler's output in the UI.
+   * @param {Object} options
+   * @param {string} options.color - A chalk method used to style output e.g. yellow, bgBlue
+   * @returns {CompilerUi}
+   */
+  create(name, options = {}) {
+    const compiler = new CompilerUi(name, options);
+    this.register(compiler);
+    return compiler;
+  }
+
+  /**
+   * Register a new CompilerUi instance. The instance can't be used until this
+   * method is called.
+   *
+   * @param {CompilerUi} compiler
+   * @returns {*}
+   */
+  register(compiler) {
+    compiler.ui = this;
+    this.compilers[compiler.name] = compiler;
+    this.output[compiler.name] = '';
+
+    compiler.start();
+    return compiler;
+  }
+
+  append(name, message) {
+    this.output[name] += message + '\n';
+    this.render();
+  }
+
+  clear(name) {
+    this.output[name] = '';
+    this.render();
+  }
+
+  start() {
+    this.started = true;
+    this.render();
+  }
+
+  render() {
+    if (!this.started) {
+      return;
+    }
+
+    if (isInteractive) {
+      clearConsole();
+
+      // We only need a top border in interactive mode - in non-interactive mode
+      // the bottom border demarcates builds.
+      printBorder('=');
+    }
+
+    Object.entries(this.compilers).forEach(([name, { options }], index) => {
+      const color = chalk.black[options.color];
+      const label = isInteractive
+        ? color(` ${options.label || name} `)
+        : `[${options.label || name}]`;
+
+      const message = this.output[name];
+      console.log(
+        message
+          .trim()
+          .split('\n')
+          .map(line => `${label}  ${line}`)
+          .join('\n')
+      );
+
+      // Build separator
+      if (index < Object.keys(this.compilers).length - 1) {
+        printBorder('-');
+      }
+    });
+
+    // Bottom border
+    printBorder('=');
+  }
+}
+
+/**
+ * @typedef {Object} CompilerUiOptions
+ * @property {string} color - A chalk method used to style output e.g. yellow, bgBlue
+ */
+
+/**
+ * The CompilerUi manages the output of a single Webpack compiler, and can pass
+ * messages back to a MultiCompilerUi to be rendered.
+ *
+ * @property {string} name
+ * @property {CompilerUiOptions} options
+ */
+class CompilerUi {
+  constructor(name, options) {
+    this.name = name;
+    this.options = options;
+  }
+
+  /**
+   * This method is called when the instance is registered with a MultiCompilerUi instance.
+   * It provides an opportunity to log a message before the first Webpack compiler
+   * event is received.
+   */
+  start() {
+    this.log('Starting...');
+    // We use this in log() to clear the initial message
+    this.new = true;
+  }
+
+  log(message = '') {
+    // We want to replace the initial starting message the first time we receive an event
+    if (this.new) {
+      this.clear();
+      this.new = false;
+    }
+
+    this.ui.append(this.name, message);
+  }
+
+  clear() {
+    this.ui.clear(this.name);
+  }
+
+  printInstructions() {}
+}
+
+/**
+ * A CompilerUi extended to show CRA's instructions for using the WebpackDevServer.
+ */
+class WebCompilerUi extends CompilerUi {
+  /**
+   *
+   * @param name
+   * @param options
+   * @param {Object} compilerConfig - Config object passed to createCustomCompiler
+   * @param {string} compilerConfig.appName
+   * @param {Object} compilerConfig.urls
+   * @param {boolean} compilerConfig.useYarn
+   */
+  constructor(name, options, compilerConfig) {
+    super(name, options);
+    this.compilerConfig = compilerConfig;
+  }
+
+  /**
+   * This function is taken directory from react-dev-utils/WebpackDevServerUtils.js,
+   * with all `console.log` references replaced with `this.log`.
+   */
+  printInstructions() {
+    const { appName, urls, useYarn } = this.compilerConfig;
+
+    this.log();
+    this.log(`You can now view ${chalk.bold(appName)} in the browser.`);
+    this.log();
+
+    if (urls.lanUrlForTerminal) {
+      this.log(
+        `  ${chalk.bold('Local:')}            ${urls.localUrlForTerminal}`
+      );
+      this.log(
+        `  ${chalk.bold('On Your Network:')}  ${urls.lanUrlForTerminal}`
+      );
+    } else {
+      this.log(`  ${urls.localUrlForTerminal}`);
+    }
+
+    this.log();
+    this.log('Note that the development build is not optimized.');
+    this.log(
+      `To create a production build, use ` +
+        `${chalk.cyan(`${useYarn ? 'yarn' : 'npm run'} build`)}.`
+    );
+    this.log();
+  }
+}
+
+function printBorder(char) {
+  console.log();
+  console.log(char.repeat(process.stdout.columns || 30));
+  console.log();
+}
+
+/**
+ * A CompilerUi designed to be used inside a forked process. It sends messages
+ * to its parent process with process.send. By convention it will send a "clear"
+ * message to denote the clear() method.
+ */
+class ProcessSendCompilerUi extends CompilerUi {
+  constructor() {
+    super();
+  }
+
+  log(message) {
+    process.send(message);
+  }
+
+  clear() {
+    process.send('clear');
+  }
+}
+
+/**
+ * A CompilerUi designed to receive messages from a ProcessSendCompilerUi. Use
+ * this instance in the parent process.
+ */
+class ProcessMessageCompilerUi extends CompilerUi {
+  constructor(childProcess, name, options) {
+    super(name, options);
+
+    childProcess.on('message', this.onMessage.bind(this));
+  }
+
+  onMessage(message) {
+    if (message === 'clear') {
+      this.clear();
+    } else {
+      this.log(message);
+    }
+  }
+}
+
+/**
+ * A CompilerUi that just logs messages - useful for debugging.
+ */
+class DebugCompilerUi extends CompilerUi {
+  constructor() {
+    super();
+  }
+
+  log(message) {
+    console.log(message);
+  }
+
+  clear() {}
+}
+
+module.exports = {
+  MultiCompilerUi,
+  WebCompilerUi,
+  ProcessSendCompilerUi,
+  ProcessMessageCompilerUi,
+  DebugCompilerUi,
+};

--- a/packages/react-scripts/scripts/utils/MultiCompilerUi.js
+++ b/packages/react-scripts/scripts/utils/MultiCompilerUi.js
@@ -81,7 +81,7 @@ class MultiCompilerUi {
     return compiler;
   }
 
-  append(name, message) {
+  append(name, message = '') {
     this.output[name] += message + '\n';
     this.render();
   }
@@ -151,6 +151,8 @@ class MultiCompilerUi {
  *
  * @property {string} name
  * @property {CompilerUiOptions} options
+ * @property {MultiCompilerUi} [ui] - When a CompilerUi instance is passed to {@link MultiCompilerUi#register},
+ *                                    the MultiCompilerUi instance is attached.
  */
 class CompilerUi {
   constructor(name, options) {
@@ -252,7 +254,7 @@ class ProcessSendCompilerUi extends CompilerUi {
     super();
   }
 
-  log(message) {
+  log(message = '') {
     process.send(message);
   }
 
@@ -289,7 +291,7 @@ class DebugCompilerUi extends CompilerUi {
     super();
   }
 
-  log(message) {
+  log(message = '') {
     console.log(message);
   }
 

--- a/packages/react-scripts/scripts/utils/MultiCompilerUi.js
+++ b/packages/react-scripts/scripts/utils/MultiCompilerUi.js
@@ -56,8 +56,7 @@ class MultiCompilerUi {
    * Create and register a basic CompilerUi.
    *
    * @param {string} name - Used to label the compiler's output in the UI.
-   * @param {Object} options
-   * @param {string} options.color - A chalk method used to style output e.g. yellow, bgBlue
+   * @param {CompilerUiOptions} options
    * @returns {CompilerUi}
    */
   create(name, options = {}) {

--- a/packages/react-scripts/scripts/utils/customWebpackUtils.js
+++ b/packages/react-scripts/scripts/utils/customWebpackUtils.js
@@ -1,0 +1,194 @@
+const chalk = require('chalk');
+const formatWebpackMessages = require('react-dev-utils/formatWebpackMessages');
+const typescriptFormatter = require('react-dev-utils/typescriptFormatter');
+const forkTsCheckerWebpackPlugin = require('react-dev-utils/ForkTsCheckerWebpackPlugin');
+
+const isInteractive = process.stdout.isTTY;
+
+/**
+ * This function overrides react-dev-utils/WebpackDevServerUtils.createCompiler.
+ * The original function directly manages console output, which doesn't work
+ * when running multiple compilers at once. This function accepts a
+ * {@link CompilerUi} instance and sends any output messages to it.
+ *
+ * It is a copy-paste of the source with the following references replaced:
+ *
+ * - console.log -> ui.log
+ * - clearConsole -> ui.clear
+ * - printInstructions -> ui.printInstructions
+ *
+ * @param {CompilerUi} ui
+ * @param {Object} config - The same config object passed to CRA's createCompiler
+ * @returns {*} - A Webpack compiler
+ */
+function createCustomCompiler(
+  ui,
+  {
+    appName,
+    config,
+    devSocket,
+    urls,
+    useYarn,
+    useTypeScript,
+    tscCompileOnError,
+    webpack,
+  }
+) {
+  // "Compiler" is a low-level interface to webpack.
+  // It lets us listen to some events and provide our own custom messages.
+  let compiler;
+  try {
+    compiler = webpack(config);
+  } catch (err) {
+    ui.log(chalk.red('Failed to compile.'));
+    ui.log();
+    ui.log(err.message || err);
+    ui.log();
+    process.exit(1);
+  }
+
+  // "invalid" event fires when you have changed a file, and webpack is
+  // recompiling a bundle. WebpackDevServer takes care to pause serving the
+  // bundle, so if you refresh, it'll wait instead of serving the old one.
+  // "invalid" is short for "bundle invalidated", it doesn't imply any errors.
+  compiler.hooks.invalid.tap('invalid', () => {
+    if (isInteractive) {
+      ui.clear();
+    }
+    ui.log('Compiling...');
+  });
+
+  let isFirstCompile = true;
+  let tsMessagesPromise;
+  let tsMessagesResolver;
+
+  if (useTypeScript) {
+    compiler.hooks.beforeCompile.tap('beforeCompile', () => {
+      tsMessagesPromise = new Promise(resolve => {
+        tsMessagesResolver = msgs => resolve(msgs);
+      });
+    });
+
+    forkTsCheckerWebpackPlugin
+      .getCompilerHooks(compiler)
+      .receive.tap('afterTypeScriptCheck', (diagnostics, lints) => {
+        const allMsgs = [...diagnostics, ...lints];
+        const format = message =>
+          `${message.file}\n${typescriptFormatter(message, true)}`;
+
+        tsMessagesResolver({
+          errors: allMsgs.filter(msg => msg.severity === 'error').map(format),
+          warnings: allMsgs
+            .filter(msg => msg.severity === 'warning')
+            .map(format),
+        });
+      });
+  }
+
+  // "done" event fires when webpack has finished recompiling the bundle.
+  // Whether or not you have warnings or errors, you will get this event.
+  compiler.hooks.done.tap('done', async stats => {
+    if (isInteractive) {
+      ui.clear();
+    }
+
+    // We have switched off the default webpack output in WebpackDevServer
+    // options so we are going to "massage" the warnings and errors and present
+    // them in a readable focused way.
+    // We only construct the warnings and errors for speed:
+    // https://github.com/facebook/create-react-app/issues/4492#issuecomment-421959548
+    const statsData = stats.toJson({
+      all: false,
+      warnings: true,
+      errors: true,
+    });
+
+    if (useTypeScript && statsData.errors.length === 0) {
+      const delayedMsg = setTimeout(() => {
+        ui.log(
+          chalk.yellow(
+            'Files successfully emitted, waiting for typecheck results...'
+          )
+        );
+      }, 100);
+
+      const messages = await tsMessagesPromise;
+      clearTimeout(delayedMsg);
+      if (tscCompileOnError) {
+        statsData.warnings.push(...messages.errors);
+      } else {
+        statsData.errors.push(...messages.errors);
+      }
+      statsData.warnings.push(...messages.warnings);
+
+      // Push errors and warnings into compilation result
+      // to show them after page refresh triggered by user.
+      if (tscCompileOnError) {
+        stats.compilation.warnings.push(...messages.errors);
+      } else {
+        stats.compilation.errors.push(...messages.errors);
+      }
+      stats.compilation.warnings.push(...messages.warnings);
+
+      if (messages.errors.length > 0) {
+        if (tscCompileOnError) {
+          devSocket.warnings(messages.errors);
+        } else {
+          devSocket.errors(messages.errors);
+        }
+      } else if (messages.warnings.length > 0) {
+        devSocket.warnings(messages.warnings);
+      }
+
+      if (isInteractive) {
+        ui.clear();
+      }
+    }
+
+    const messages = formatWebpackMessages(statsData);
+    const isSuccessful = !messages.errors.length && !messages.warnings.length;
+    if (isSuccessful) {
+      ui.log(chalk.green('Compiled successfully!'));
+    }
+    if (isSuccessful && (isInteractive || isFirstCompile)) {
+      ui.printInstructions(appName, urls, useYarn);
+    }
+    isFirstCompile = false;
+
+    // If errors exist, only show errors.
+    if (messages.errors.length) {
+      // Only keep the first error. Others are often indicative
+      // of the same problem, but confuse the reader with noise.
+      if (messages.errors.length > 1) {
+        messages.errors.length = 1;
+      }
+      ui.log(chalk.red('Failed to compile.\n'));
+      ui.log(messages.errors.join('\n\n'));
+      return;
+    }
+
+    // Show warnings if no errors were found.
+    if (messages.warnings.length) {
+      ui.log(chalk.yellow('Compiled with warnings.\n'));
+      ui.log(messages.warnings.join('\n\n'));
+
+      // Teach some ESLint tricks.
+      ui.log(
+        '\nSearch for the ' +
+          chalk.underline(chalk.yellow('keywords')) +
+          ' to learn more about each warning.'
+      );
+      ui.log(
+        'To ignore, add ' +
+          chalk.cyan('// eslint-disable-next-line') +
+          ' to the line before.\n'
+      );
+    }
+  });
+
+  return compiler;
+}
+
+module.exports = {
+  createCustomCompiler,
+};

--- a/packages/react-scripts/scripts/utils/customWebpackUtils.js
+++ b/packages/react-scripts/scripts/utils/customWebpackUtils.js
@@ -3,7 +3,11 @@ const formatWebpackMessages = require('react-dev-utils/formatWebpackMessages');
 const typescriptFormatter = require('react-dev-utils/typescriptFormatter');
 const forkTsCheckerWebpackPlugin = require('react-dev-utils/ForkTsCheckerWebpackPlugin');
 
-const isInteractive = process.stdout.isTTY;
+/**
+ * We set this to true so that we always call ui.clear() - we check for a TTY
+ * inside {@link MultiCompilerUi}.
+ */
+const isInteractive = true;
 
 /**
  * This function overrides react-dev-utils/WebpackDevServerUtils.createCompiler.
@@ -13,9 +17,12 @@ const isInteractive = process.stdout.isTTY;
  *
  * It is a copy-paste of the source with the following references replaced:
  *
- * - console.log -> ui.log
- * - clearConsole -> ui.clear
- * - printInstructions -> ui.printInstructions
+ * - console.log() -> ui.log()
+ * - clearConsole() -> ui.clear()
+ * - printInstructions() -> ui.printInstructions()
+ *
+ * To update this function in the future when CRA changes, just copy the original
+ * here and make the updates above.
  *
  * @param {CompilerUi} ui
  * @param {Object} config - The same config object passed to CRA's createCompiler

--- a/packages/react-scripts/scripts/utils/forkSsr.js
+++ b/packages/react-scripts/scripts/utils/forkSsr.js
@@ -1,0 +1,66 @@
+/**
+ * This script runs a Webpack compiler to watch the SSR build. It is designed to
+ * be run by child_process.fork from the start-ssr script.
+ */
+
+const fs = require('fs');
+const webpack = require('webpack');
+const { prepareUrls } = require('react-dev-utils/WebpackDevServerUtils');
+const paths = require('../../config/paths');
+
+const ssrConfigFactory = require('../../config/webpack.config.ssr');
+const statusFile = require('./statusFile');
+const { DebugCompilerUi, ProcessSendCompilerUi } = require('./MultiCompilerUi');
+const { createCustomCompiler } = require('./customWebpackUtils');
+
+const useYarn = fs.existsSync(paths.yarnLockFile);
+
+const config = ssrConfigFactory('development');
+const appName = require(paths.appPackageJson).name;
+
+const useTypeScript = fs.existsSync(paths.appTsConfig);
+const tscCompileOnError = process.env.TSC_COMPILE_ON_ERROR === 'true';
+
+// We don't start a DevServer so we can use dummy URLs
+const urls = prepareUrls(
+  'http', // protocol
+  'localhost', // HOST
+  '3000', // port
+  paths.publicUrlOrPath.slice(0, -1)
+);
+
+// We don't start a DevServer so we can drop devSocket messages
+const devSocket = {
+  warnings: () => {},
+  errors: () => {},
+};
+
+const ui = process.send ? new ProcessSendCompilerUi() : new DebugCompilerUi();
+
+const compiler = createCustomCompiler(ui, {
+  appName,
+  config,
+  devSocket,
+  urls,
+  useYarn,
+  useTypeScript,
+  tscCompileOnError,
+  webpack,
+});
+
+statusFile.init(compiler, paths.appBuildWeb);
+
+compiler.watch(
+  {
+    ignored: ['node_modules'],
+  },
+  err => {
+    if (err) {
+      // TODO: Fix this
+      console.log(err.message || err);
+      process.exit(1);
+    }
+
+    statusFile.done(paths.appBuildSsr);
+  }
+);

--- a/packages/react-scripts/scripts/utils/forkSsr.js
+++ b/packages/react-scripts/scripts/utils/forkSsr.js
@@ -3,6 +3,7 @@
  * be run by child_process.fork from the start-ssr script.
  */
 
+const chalk = require('chalk');
 const fs = require('fs');
 const webpack = require('webpack');
 const { prepareUrls } = require('react-dev-utils/WebpackDevServerUtils');
@@ -56,8 +57,8 @@ compiler.watch(
   },
   err => {
     if (err) {
-      // TODO: Fix this
-      console.log(err.message || err);
+      ui.clear();
+      ui.log(chalk.red('Failed to compile:') + '\n' + (err.message || err));
       process.exit(1);
     }
 


### PR DESCRIPTION
This PR supersedes #96.

## Description

The current `v9-alpha` with Loadable SSR support adds a `start-ssr` script to run the SSR build during development, which means having to run `react-scripts start` and `react-scripts start-ssr` in parallel. This doesn't play well with how Docker is set up in MShell microsites - the `client` container can only run one process.

Vulcan have run a spike to look in to options to improve this and agreed the approach here with @olliecurtis, which is to update the `start-ssr` script to run both the `web` and `ssr` builds in dev mode:

- A `WebpackDevServer` runs watches the `web` build on serves files on `localhost:3000`, exactly as `start` does
- A second Webpack compiler watches the `ssr` build and writes to the filesystem

The `start-ssr` script is now a clone of `start` with changes - this hopefully makes it easier to rebase in the future.

The crux of how it works is not using `react-dev-utils/WebpackDevServerUtils#createCompiler`, because it attaches a bunch of event listeners to Webpack that clear and write to the console. If you create
2 compilers they overwrite each other and the output is unreadable.

This branch was developed and tested inside Vulcan's `skyscanner-local-components` project, and tested with `@skyscanner/backpack-react-scripts@9.2.0-alpha.2c740a6a`.

## Details

We've refactored from the #96 PR against v8 to make it easier to keep the `start-ssr` script up to date as CRA changes. It moves as much code as possible out of the script in to files in `utils`. See code comments for more details.

## Next steps

- [x] @olliecurtis to review
- [ ] Merge in to v9 SSR branch and test with Local Components
- [ ] Release new v9-alpha and test in a real microsite

## Examples

Interactive mode:

https://user-images.githubusercontent.com/1162326/122892066-fe20e800-d33c-11eb-92e3-52fc556f3dfd.mov

Non-interactive mode (eg Docker):

https://user-images.githubusercontent.com/1162326/122893643-6ae8b200-d33e-11eb-9ef6-22964fc365e9.mov
