### PR TITLE
[LEOP-55]: Apply cache-loader on CI

### DIFF
--- a/packages/react-scripts/CHANGELOG.md
+++ b/packages/react-scripts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # `backpack-react-scripts` Change Log
 
+## 9.3.0
+
+- Apply `cache-loader` on CI
+  - Put `cache-loader` before `sass-loader` since `sass-loader` is the most expensive
+  - Add `SHOULD_USE_CACHE_LOADER` to control if use `cache-loader` or not since not all the web projects at Skyscanner have applied the cache strategy
+
 ## 9.2.0
 
 - Added `ignoreCssWarnings` config item to allow the ability to supress CSS ordering issues when its safe to allow mixed order when it has not effect on output. https://github.com/webpack-contrib/mini-css-extract-plugin#remove-order-warnings

--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -106,7 +106,8 @@ module.exports = {
   ownNodeModules: resolveOwn('node_modules'), // This is empty on npm 3
   appTypeDeclarations: resolveApp('src/react-app-env.d.ts'),
   ownTypeDeclarations: resolveOwn('lib/react-app.d.ts'),
-  cacheLoaderDir: resolveOwn('.cache/cache-loader'),
+  // Make all the caches (Babel-loader, cache-loader & Terser-webpack-plugin) in one single folder
+  cacheLoaderDir: resolveApp('./node_modules/.cache/cache-loader'),
 };
 
 const ownPackageJson = require('../package.json');
@@ -144,7 +145,8 @@ if (
     ownNodeModules: resolveOwn('node_modules'),
     appTypeDeclarations: resolveOwn(`${templatePath}/src/react-app-env.d.ts`),
     ownTypeDeclarations: resolveOwn('lib/react-app.d.ts'),
-    cacheLoaderDir: resolveOwn('.cache/cache-loader'),
+    // Make all the caches (Babel-loader, cache-loader & Terser-webpack-plugin) in one single folder
+    cacheLoaderDir: resolveApp('./node_modules/.cache/cache-loader'),
   };
 }
 // @remove-on-eject-end

--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -106,7 +106,7 @@ module.exports = {
   ownNodeModules: resolveOwn('node_modules'), // This is empty on npm 3
   appTypeDeclarations: resolveApp('src/react-app-env.d.ts'),
   ownTypeDeclarations: resolveOwn('lib/react-app.d.ts'),
-  // Make all the caches (Babel-loader, cache-loader & Terser-webpack-plugin) in one single folder
+  // Make all the caches (Babel-loader, Cache-loader & Terser-webpack-plugin) in one single folder
   cacheLoaderDir: resolveApp('./node_modules/.cache/cache-loader'),
 };
 
@@ -145,7 +145,7 @@ if (
     ownNodeModules: resolveOwn('node_modules'),
     appTypeDeclarations: resolveOwn(`${templatePath}/src/react-app-env.d.ts`),
     ownTypeDeclarations: resolveOwn('lib/react-app.d.ts'),
-    // Make all the caches (Babel-loader, cache-loader & Terser-webpack-plugin) in one single folder
+    // Make all the caches (Babel-loader, Cache-loader & Terser-webpack-plugin) in one single folder
     cacheLoaderDir: resolveApp('./node_modules/.cache/cache-loader'),
   };
 }

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -139,6 +139,11 @@ module.exports = function (webpackEnv) {
 
   const shouldUseReactRefresh = env.raw.FAST_REFRESH;
 
+  // SHOULD_USE_CACHE_LOADER - this environment variable is not from Create React App side, it shouldn't be added to `env.js` file to get its value, and it should be deleted when cache strategy is ready for all the web teams at Skyscanner
+  // Warning: cache-loader won't be needed when webpack 5 is there
+  const shouldUseCacheLoader =
+    isEnvProduction && process.env.SHOULD_USE_CACHE_LOADER;
+
   // common function to get style loaders
   const getStyleLoaders = (
     cssOptions,
@@ -154,12 +159,6 @@ module.exports = function (webpackEnv) {
         options: paths.publicUrlOrPath.startsWith('.')
           ? { publicPath: '../../' }
           : {},
-      },
-      isEnvDevelopment && {
-        loader: require.resolve('cache-loader'),
-        options: {
-          cacheDirectory: paths.cacheLoaderDir,
-        },
       },
       {
         loader: require.resolve('css-loader'),
@@ -193,22 +192,34 @@ module.exports = function (webpackEnv) {
     ].filter(Boolean);
     if (preProcessor) {
       loaders.push(
-        {
-          loader: require.resolve('resolve-url-loader'),
-          options: {
-            sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
-            root: paths.appSrc,
-          },
-        },
-        {
-          loader: require.resolve(preProcessor),
-          options: {
-            ...preProcessorOptions,
-            ...{
-              sourceMap: true,
+        ...[
+          {
+            loader: require.resolve('resolve-url-loader'),
+            options: {
+              sourceMap: isEnvProduction
+                ? shouldUseSourceMap
+                : isEnvDevelopment,
+              root: paths.appSrc,
             },
           },
-        }
+          // Because sass-loader is the most expensive, so put cache-loader here to only cache sass-loader
+          // Note that there is an overhead for saving the reading and saving the cache file, so only use this loader to cache expensive loaders.
+          shouldUseCacheLoader && {
+            loader: require.resolve('cache-loader'),
+            options: {
+              cacheDirectory: paths.cacheLoaderDir,
+            },
+          },
+          {
+            loader: require.resolve(preProcessor),
+            options: {
+              ...preProcessorOptions,
+              ...{
+                sourceMap: true,
+              },
+            },
+          },
+        ].filter(Boolean)
       );
     }
     return loaders;
@@ -562,12 +573,6 @@ module.exports = function (webpackEnv) {
                   loader: require.resolve('thread-loader'),
                   options: jsWorkerPool,
                 },
-                isEnvDevelopment && {
-                  loader: require.resolve('cache-loader'),
-                  options: {
-                    cacheDirectory: paths.cacheLoaderDir,
-                  },
-                },
                 {
                   loader: require.resolve('babel-loader'),
                   options: {
@@ -634,49 +639,39 @@ module.exports = function (webpackEnv) {
             {
               test: /\.(js|mjs)$/,
               exclude: /@babel(?:\/|\\{1,2})runtime/,
-              use: [
-                isEnvDevelopment && {
-                  loader: require.resolve('cache-loader'),
-                  options: {
-                    cacheDirectory: paths.cacheLoaderDir,
-                  },
-                },
-                {
-                  loader: require.resolve('babel-loader'),
-                  options: {
-                    babelrc: false,
-                    configFile: false,
-                    compact: false,
-                    presets: [
-                      [
-                        require.resolve('babel-preset-react-app/dependencies'),
-                        { helpers: true },
-                      ],
-                    ],
-                    cacheDirectory: true,
-                    // See #6846 for context on why cacheCompression is disabled
-                    cacheCompression: false,
-                    // @remove-on-eject-begin
-                    cacheIdentifier: getCacheIdentifier(
-                      isEnvProduction
-                        ? 'production'
-                        : isEnvDevelopment && 'development',
-                      [
-                        'babel-plugin-named-asset-import',
-                        'babel-preset-react-app',
-                        'react-dev-utils',
-                        'react-scripts',
-                      ]
-                    ),
-                    // @remove-on-eject-end
-                    // Babel sourcemaps are needed for debugging into node_modules
-                    // code.  Without the options below, debuggers like VSCode
-                    // show incorrect code and set breakpoints on the wrong lines.
-                    sourceMaps: shouldUseSourceMap,
-                    inputSourceMap: shouldUseSourceMap,
-                  },
-                },
-              ].filter(Boolean),
+              loader: require.resolve('babel-loader'),
+              options: {
+                babelrc: false,
+                configFile: false,
+                compact: false,
+                presets: [
+                  [
+                    require.resolve('babel-preset-react-app/dependencies'),
+                    { helpers: true },
+                  ],
+                ],
+                cacheDirectory: true,
+                // See #6846 for context on why cacheCompression is disabled
+                cacheCompression: false,
+                // @remove-on-eject-begin
+                cacheIdentifier: getCacheIdentifier(
+                  isEnvProduction
+                    ? 'production'
+                    : isEnvDevelopment && 'development',
+                  [
+                    'babel-plugin-named-asset-import',
+                    'babel-preset-react-app',
+                    'react-dev-utils',
+                    'react-scripts',
+                  ]
+                ),
+                // @remove-on-eject-end
+                // Babel sourcemaps are needed for debugging into node_modules
+                // code.  Without the options below, debuggers like VSCode
+                // show incorrect code and set breakpoints on the wrong lines.
+                sourceMaps: shouldUseSourceMap,
+                inputSourceMap: shouldUseSourceMap,
+              },
             },
             // "postcss" loader applies autoprefixer to our CSS.
             // "css" loader resolves paths in CSS and adds assets as dependencies.
@@ -740,7 +735,9 @@ module.exports = function (webpackEnv) {
               exclude: sassModuleRegex,
               use: getStyleLoaders(
                 {
-                  importLoaders: 3,
+                  // When using sass-loader, the total count of loaders is up to 4 including cache-loader below the css-loader
+                  // When not using sass-loader, the total count of loaders is 3 not including cache-loader below the css-loader
+                  importLoaders: shouldUseCacheLoader ? 4 : 3,
                   sourceMap: isEnvProduction
                     ? shouldUseSourceMap
                     : isEnvDevelopment,
@@ -774,7 +771,9 @@ module.exports = function (webpackEnv) {
               ],
               use: getStyleLoaders(
                 {
-                  importLoaders: 3,
+                  // When using sass-loader, the total count of loaders is up to 4 including cache-loader below the css-loader
+                  // When not using sass-loader, the total count of loaders is 3 not including cache-loader below the css-loader
+                  importLoaders: shouldUseCacheLoader ? 4 : 3,
                   sourceMap: isEnvProduction
                     ? shouldUseSourceMap
                     : isEnvDevelopment,

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -141,8 +141,7 @@ module.exports = function (webpackEnv) {
 
   // SHOULD_USE_CACHE_LOADER - this environment variable is not from Create React App side, it shouldn't be added to `env.js` file to get its value, and it should be deleted when cache strategy is ready for all the web teams at Skyscanner
   // Warning: cache-loader won't be needed when webpack 5 is there
-  const shouldUseCacheLoader =
-    isEnvProduction && process.env.SHOULD_USE_CACHE_LOADER;
+  const shouldUseCacheLoader = process.env.SHOULD_USE_CACHE_LOADER;
 
   // common function to get style loaders
   const getStyleLoaders = (
@@ -192,34 +191,32 @@ module.exports = function (webpackEnv) {
     ].filter(Boolean);
     if (preProcessor) {
       loaders.push(
-        ...[
-          {
-            loader: require.resolve('resolve-url-loader'),
-            options: {
-              sourceMap: isEnvProduction
-                ? shouldUseSourceMap
-                : isEnvDevelopment,
-              root: paths.appSrc,
+        ...[{
+          loader: require.resolve('resolve-url-loader'),
+          options: {
+            sourceMap: isEnvProduction
+              ? shouldUseSourceMap
+              : isEnvDevelopment,
+            root: paths.appSrc,
+          },
+        },
+        // Because sass-loader is the most expensive, so put cache-loader here to only cache sass-loader
+        // Note that there is an overhead for saving the reading and saving the cache file, so only use this loader to cache expensive loaders.
+        shouldUseCacheLoader && {
+          loader: require.resolve('cache-loader'),
+          options: {
+            cacheDirectory: paths.cacheLoaderDir,
+          },
+        },
+        {
+          loader: require.resolve(preProcessor),
+          options: {
+            ...preProcessorOptions,
+            ...{
+              sourceMap: true,
             },
           },
-          // Because sass-loader is the most expensive, so put cache-loader here to only cache sass-loader
-          // Note that there is an overhead for saving the reading and saving the cache file, so only use this loader to cache expensive loaders.
-          shouldUseCacheLoader && {
-            loader: require.resolve('cache-loader'),
-            options: {
-              cacheDirectory: paths.cacheLoaderDir,
-            },
-          },
-          {
-            loader: require.resolve(preProcessor),
-            options: {
-              ...preProcessorOptions,
-              ...{
-                sourceMap: true,
-              },
-            },
-          },
-        ].filter(Boolean)
+        }].filter(Boolean),
       );
     }
     return loaders;

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -191,32 +191,32 @@ module.exports = function (webpackEnv) {
     ].filter(Boolean);
     if (preProcessor) {
       loaders.push(
-        ...[{
-          loader: require.resolve('resolve-url-loader'),
-          options: {
-            sourceMap: isEnvProduction
-              ? shouldUseSourceMap
-              : isEnvDevelopment,
-            root: paths.appSrc,
-          },
-        },
-        // Because sass-loader is the most expensive, so put cache-loader here to only cache sass-loader
-        // Note that there is an overhead for saving the reading and saving the cache file, so only use this loader to cache expensive loaders.
-        shouldUseCacheLoader && {
-          loader: require.resolve('cache-loader'),
-          options: {
-            cacheDirectory: paths.cacheLoaderDir,
-          },
-        },
-        {
-          loader: require.resolve(preProcessor),
-          options: {
-            ...preProcessorOptions,
-            ...{
-              sourceMap: true,
+        ...[
+          {
+            loader: require.resolve('resolve-url-loader'),
+            options: {
+              sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
+              root: paths.appSrc,
             },
           },
-        }].filter(Boolean),
+          // Because sass-loader is the most expensive, so put cache-loader here to only cache sass-loader
+          // Note that there is an overhead for saving the reading and saving the cache file, so only use this loader to cache expensive loaders.
+          shouldUseCacheLoader && {
+            loader: require.resolve('cache-loader'),
+            options: {
+              cacheDirectory: paths.cacheLoaderDir,
+            },
+          },
+          {
+            loader: require.resolve(preProcessor),
+            options: {
+              ...preProcessorOptions,
+              ...{
+                sourceMap: true,
+              },
+            },
+          },
+        ].filter(Boolean),
       );
     }
     return loaders;

--- a/packages/react-scripts/config/webpack.config.ssr.js
+++ b/packages/react-scripts/config/webpack.config.ssr.js
@@ -137,7 +137,7 @@ module.exports = function (webpackEnv) {
 
   // SHOULD_USE_CACHE_LOADER - this environment variable is not from Create React App side, it shouldn't be added to `env.js` file to get its value, and it should be deleted when cache strategy is ready for all the web teams at Skyscanner
   // Warning: cache-loader won't be needed when webpack 5 is there
-  // const shouldUseCacheLoader = isEnvProduction && process.env.SHOULD_USE_CACHE_LOADER;
+  // const shouldUseCacheLoader = process.env.SHOULD_USE_CACHE_LOADER;
 
   // common function to get style loaders
   const getStyleLoaders = (
@@ -187,32 +187,32 @@ module.exports = function (webpackEnv) {
     ].filter(Boolean);
     if (preProcessor) {
       loaders.push(
-        ...[
-          {
-            loader: require.resolve('resolve-url-loader'),
-            options: {
-              sourceMap: isEnvProduction
-                ? shouldUseSourceMap
-                : isEnvDevelopment,
-              root: paths.appSrc,
+        ...[{
+          loader: require.resolve('resolve-url-loader'),
+          options: {
+            sourceMap: isEnvProduction
+              ? shouldUseSourceMap
+              : isEnvDevelopment,
+            root: paths.appSrc,
+          },
+        },
+        // Because sass-loader is the most expensive, so put cache-loader here to only cache sass-loader
+        // Note that there is an overhead for saving the reading and saving the cache file, so only use this loader to cache expensive loaders.
+        // shouldUseCacheLoader && {
+        //   loader: require.resolve('cache-loader'),
+        //   options: {
+        //     cacheDirectory: paths.cacheLoaderDir,
+        //   },
+        // },
+        {
+          loader: require.resolve(preProcessor),
+          options: {
+            ...preProcessorOptions,
+            ...{
+              sourceMap: true,
             },
           },
-          // shouldUseCacheLoader && {
-          //   loader: require.resolve('cache-loader'),
-          //   options: {
-          //     cacheDirectory: paths.cacheLoaderDir,
-          //   },
-          // },
-          {
-            loader: require.resolve(preProcessor),
-            options: {
-              ...preProcessorOptions,
-              ...{
-                sourceMap: true,
-              },
-            },
-          },
-        ].filter(Boolean)
+        }].filter(Boolean),
       );
     }
     return loaders;

--- a/packages/react-scripts/config/webpack.config.ssr.js
+++ b/packages/react-scripts/config/webpack.config.ssr.js
@@ -187,32 +187,32 @@ module.exports = function (webpackEnv) {
     ].filter(Boolean);
     if (preProcessor) {
       loaders.push(
-        ...[{
-          loader: require.resolve('resolve-url-loader'),
-          options: {
-            sourceMap: isEnvProduction
-              ? shouldUseSourceMap
-              : isEnvDevelopment,
-            root: paths.appSrc,
-          },
-        },
-        // Because sass-loader is the most expensive, so put cache-loader here to only cache sass-loader
-        // Note that there is an overhead for saving the reading and saving the cache file, so only use this loader to cache expensive loaders.
-        // shouldUseCacheLoader && {
-        //   loader: require.resolve('cache-loader'),
-        //   options: {
-        //     cacheDirectory: paths.cacheLoaderDir,
-        //   },
-        // },
-        {
-          loader: require.resolve(preProcessor),
-          options: {
-            ...preProcessorOptions,
-            ...{
-              sourceMap: true,
+        ...[
+          {
+            loader: require.resolve('resolve-url-loader'),
+            options: {
+              sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
+              root: paths.appSrc,
             },
           },
-        }].filter(Boolean),
+          // Because sass-loader is the most expensive, so put cache-loader here to only cache sass-loader
+          // Note that there is an overhead for saving the reading and saving the cache file, so only use this loader to cache expensive loaders.
+          // shouldUseCacheLoader && {
+          //   loader: require.resolve('cache-loader'),
+          //   options: {
+          //     cacheDirectory: paths.cacheLoaderDir,
+          //   },
+          // },
+          {
+            loader: require.resolve(preProcessor),
+            options: {
+              ...preProcessorOptions,
+              ...{
+                sourceMap: true,
+              },
+            },
+          },
+        ].filter(Boolean),
       );
     }
     return loaders;

--- a/packages/react-scripts/config/webpack.config.ssr.js
+++ b/packages/react-scripts/config/webpack.config.ssr.js
@@ -135,6 +135,10 @@ module.exports = function (webpackEnv) {
 
   const shouldUseReactRefresh = env.raw.FAST_REFRESH;
 
+  // SHOULD_USE_CACHE_LOADER - this environment variable is not from Create React App side, it shouldn't be added to `env.js` file to get its value, and it should be deleted when cache strategy is ready for all the web teams at Skyscanner
+  // Warning: cache-loader won't be needed when webpack 5 is there
+  // const shouldUseCacheLoader = isEnvProduction && process.env.SHOULD_USE_CACHE_LOADER;
+
   // common function to get style loaders
   const getStyleLoaders = (
     cssOptions,
@@ -151,12 +155,6 @@ module.exports = function (webpackEnv) {
           ? { publicPath: '../../' }
           : {},
       },
-      // isEnvDevelopment && {
-      //   loader: require.resolve('cache-loader'),
-      //   options: {
-      //     cacheDirectory: paths.cacheLoaderDir,
-      //   },
-      // },
       {
         loader: require.resolve('css-loader'),
         options: cssOptions,
@@ -189,22 +187,32 @@ module.exports = function (webpackEnv) {
     ].filter(Boolean);
     if (preProcessor) {
       loaders.push(
-        {
-          loader: require.resolve('resolve-url-loader'),
-          options: {
-            sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
-            root: paths.appSrc,
-          },
-        },
-        {
-          loader: require.resolve(preProcessor),
-          options: {
-            ...preProcessorOptions,
-            ...{
-              sourceMap: true,
+        ...[
+          {
+            loader: require.resolve('resolve-url-loader'),
+            options: {
+              sourceMap: isEnvProduction
+                ? shouldUseSourceMap
+                : isEnvDevelopment,
+              root: paths.appSrc,
             },
           },
-        }
+          // shouldUseCacheLoader && {
+          //   loader: require.resolve('cache-loader'),
+          //   options: {
+          //     cacheDirectory: paths.cacheLoaderDir,
+          //   },
+          // },
+          {
+            loader: require.resolve(preProcessor),
+            options: {
+              ...preProcessorOptions,
+              ...{
+                sourceMap: true,
+              },
+            },
+          },
+        ].filter(Boolean)
       );
     }
     return loaders;
@@ -564,12 +572,6 @@ module.exports = function (webpackEnv) {
                 //   loader: require.resolve('thread-loader'),
                 //   options: jsWorkerPool,
                 // },
-                // isEnvDevelopment && {
-                //   loader: require.resolve('cache-loader'),
-                //   options: {
-                //     cacheDirectory: paths.cacheLoaderDir,
-                //   },
-                // },
                 {
                   loader: require.resolve('babel-loader'),
                   options: {
@@ -636,49 +638,39 @@ module.exports = function (webpackEnv) {
             {
               test: /\.(js|mjs)$/,
               exclude: /@babel(?:\/|\\{1,2})runtime/,
-              use: [
-                // isEnvDevelopment && {
-                //   loader: require.resolve('cache-loader'),
-                //   options: {
-                //     cacheDirectory: paths.cacheLoaderDir,
-                //   },
-                // },
-                {
-                  loader: require.resolve('babel-loader'),
-                  options: {
-                    babelrc: false,
-                    configFile: false,
-                    compact: false,
-                    presets: [
-                      [
-                        require.resolve('babel-preset-react-app/dependencies'),
-                        { helpers: true },
-                      ],
-                    ],
-                    cacheDirectory: true,
-                    // See #6846 for context on why cacheCompression is disabled
-                    cacheCompression: false,
-                    // @remove-on-eject-begin
-                    cacheIdentifier: getCacheIdentifier(
-                      isEnvProduction
-                        ? 'production'
-                        : isEnvDevelopment && 'development',
-                      [
-                        'babel-plugin-named-asset-import',
-                        'babel-preset-react-app',
-                        'react-dev-utils',
-                        'react-scripts',
-                      ]
-                    ),
-                    // @remove-on-eject-end
-                    // Babel sourcemaps are needed for debugging into node_modules
-                    // code.  Without the options below, debuggers like VSCode
-                    // show incorrect code and set breakpoints on the wrong lines.
-                    sourceMaps: shouldUseSourceMap,
-                    inputSourceMap: shouldUseSourceMap,
-                  },
-                },
-              ].filter(Boolean),
+              loader: require.resolve('babel-loader'),
+              options: {
+                babelrc: false,
+                configFile: false,
+                compact: false,
+                presets: [
+                  [
+                    require.resolve('babel-preset-react-app/dependencies'),
+                    { helpers: true },
+                  ],
+                ],
+                cacheDirectory: true,
+                // See #6846 for context on why cacheCompression is disabled
+                cacheCompression: false,
+                // @remove-on-eject-begin
+                cacheIdentifier: getCacheIdentifier(
+                  isEnvProduction
+                    ? 'production'
+                    : isEnvDevelopment && 'development',
+                  [
+                    'babel-plugin-named-asset-import',
+                    'babel-preset-react-app',
+                    'react-dev-utils',
+                    'react-scripts',
+                  ]
+                ),
+                // @remove-on-eject-end
+                // Babel sourcemaps are needed for debugging into node_modules
+                // code.  Without the options below, debuggers like VSCode
+                // show incorrect code and set breakpoints on the wrong lines.
+                sourceMaps: shouldUseSourceMap,
+                inputSourceMap: shouldUseSourceMap,
+              },
             },
             // "postcss" loader applies autoprefixer to our CSS.
             // "css" loader resolves paths in CSS and adds assets as dependencies.
@@ -742,6 +734,9 @@ module.exports = function (webpackEnv) {
               exclude: sassModuleRegex,
               use: getStyleLoaders(
                 {
+                  // When using sass-loader, the total count of loaders is up to 4 including cache-loader below the css-loader
+                  // When not using sass-loader, the total count of loaders is 3 not including cache-loader below the css-loader
+                  // importLoaders: shouldUseCacheLoader ? 4 : 3,
                   importLoaders: 3,
                   sourceMap: isEnvProduction
                     ? shouldUseSourceMap
@@ -776,6 +771,9 @@ module.exports = function (webpackEnv) {
               ],
               use: getStyleLoaders(
                 {
+                  // When using sass-loader, the total count of loaders is up to 4 including cache-loader below the css-loader
+                  // When not using sass-loader, the total count of loaders is 3 not including cache-loader below the css-loader
+                  // importLoaders: shouldUseCacheLoader ? 4 : 3,
                   importLoaders: 3,
                   sourceMap: isEnvProduction
                     ? shouldUseSourceMap


### PR DESCRIPTION
## Why?

From [LEOP-69](https://gojira.skyscanner.net/browse/LEOP-69), we can get the benefit from `cache-loader` on CI.
More detail Here: [cache-loader on GitHub Actions](https://github.com/Skyscanner/test-banana/actions/runs/1014476314)

## Change List

- Apply `cache-loader` on CI
    - Put `cache-loader` before `sass-loader` since `sass-loader` is the most expensive
    - Add `SHOULD_USE_CACHE_LOADER` to control if use `cache-loader` or not since not all the web projects at Skyscanner have applied the cache strategy
