### PR TITLE
[LEOP-166]: Move cache-loader above resolve-url-loader to get the best performance

### DIFF
--- a/packages/react-scripts/CHANGELOG.md
+++ b/packages/react-scripts/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## 9.3.1
 
 - Move `cache-loader` above `resolve-url-loader` to get the best performance
-
+  - Note that there is an overhead for saving the reading and saving the cache file, so only use this loader to cache expensive loaders. It is said that `cache-loader` shouldn't deal with all the loaders and only the expensive parts.
+  - Moving `cache-loader` above resolve-url-loader is because cache files it generates after this operation are small and it is faster to read the cache files, and it saves more time than `cache-loader` below resolve-url-loader, we can still speed up the process of compiling sass to css since sass-loader is the most expensive
+      
 ## 9.3.0
 
 - Apply `cache-loader` on CI

--- a/packages/react-scripts/CHANGELOG.md
+++ b/packages/react-scripts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `backpack-react-scripts` Change Log
 
+## 9.3.1
+
+- Move `cache-loader` above `resolve-url-loader` to get the best performance
+
 ## 9.3.0
 
 - Apply `cache-loader` on CI

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -192,8 +192,6 @@ module.exports = function (webpackEnv) {
     if (preProcessor) {
       loaders.push(
         ...[
-          // Moving cache-loader above resolve-url-loader is because its cache files are small and it is faster to read the cache files, and it saves more time than cache-loader below resolve-url-loader, we can still speed up the process of compiling sass to css since sass-loader is the most expensive
-          // Note that there is an overhead for saving the reading and saving the cache file, so only use this loader to cache expensive loaders.
           shouldUseCacheLoader && {
             loader: require.resolve('cache-loader'),
             options: {

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -192,19 +192,19 @@ module.exports = function (webpackEnv) {
     if (preProcessor) {
       loaders.push(
         ...[
-          {
-            loader: require.resolve('resolve-url-loader'),
-            options: {
-              sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
-              root: paths.appSrc,
-            },
-          },
-          // Because sass-loader is the most expensive, so put cache-loader here to only cache sass-loader
+          // Moving cache-loader above resolve-url-loader is because its cache files are small and it is faster to read the cache files, and it saves more time than cache-loader below resolve-url-loader, we can still speed up the process of compiling sass to css since sass-loader is the most expensive
           // Note that there is an overhead for saving the reading and saving the cache file, so only use this loader to cache expensive loaders.
           shouldUseCacheLoader && {
             loader: require.resolve('cache-loader'),
             options: {
               cacheDirectory: paths.cacheLoaderDir,
+            },
+          },
+          {
+            loader: require.resolve('resolve-url-loader'),
+            options: {
+              sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
+              root: paths.appSrc,
             },
           },
           {
@@ -732,8 +732,8 @@ module.exports = function (webpackEnv) {
               exclude: sassModuleRegex,
               use: getStyleLoaders(
                 {
-                  // When using sass-loader, the total count of loaders is up to 4 including cache-loader below the css-loader
-                  // When not using sass-loader, the total count of loaders is 3 not including cache-loader below the css-loader
+                  // When using cache-loader, the total count of loaders is up to 4 including cache-loader below the css-loader
+                  // When not using cache-loader, the total count of loaders is 3 not including cache-loader below the css-loader
                   importLoaders: shouldUseCacheLoader ? 4 : 3,
                   sourceMap: isEnvProduction
                     ? shouldUseSourceMap
@@ -768,8 +768,8 @@ module.exports = function (webpackEnv) {
               ],
               use: getStyleLoaders(
                 {
-                  // When using sass-loader, the total count of loaders is up to 4 including cache-loader below the css-loader
-                  // When not using sass-loader, the total count of loaders is 3 not including cache-loader below the css-loader
+                  // When using cache-loader, the total count of loaders is up to 4 including cache-loader below the css-loader
+                  // When not using cache-loader, the total count of loaders is 3 not including cache-loader below the css-loader
                   importLoaders: shouldUseCacheLoader ? 4 : 3,
                   sourceMap: isEnvProduction
                     ? shouldUseSourceMap

--- a/packages/react-scripts/config/webpack.config.ssr.js
+++ b/packages/react-scripts/config/webpack.config.ssr.js
@@ -188,8 +188,6 @@ module.exports = function (webpackEnv) {
     if (preProcessor) {
       loaders.push(
         ...[
-          // Moving cache-loader above resolve-url-loader is because its cache files are small and it is faster to read the cache files, and it saves more time than cache-loader below resolve-url-loader, we can still speed up the process of compiling sass to css since sass-loader is the most expensive
-          // Note that there is an overhead for saving the reading and saving the cache file, so only use this loader to cache expensive loaders.
           // shouldUseCacheLoader && {
           //   loader: require.resolve('cache-loader'),
           //   options: {

--- a/packages/react-scripts/config/webpack.config.ssr.js
+++ b/packages/react-scripts/config/webpack.config.ssr.js
@@ -188,14 +188,7 @@ module.exports = function (webpackEnv) {
     if (preProcessor) {
       loaders.push(
         ...[
-          {
-            loader: require.resolve('resolve-url-loader'),
-            options: {
-              sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
-              root: paths.appSrc,
-            },
-          },
-          // Because sass-loader is the most expensive, so put cache-loader here to only cache sass-loader
+          // Moving cache-loader above resolve-url-loader is because its cache files are small and it is faster to read the cache files, and it saves more time than cache-loader below resolve-url-loader, we can still speed up the process of compiling sass to css since sass-loader is the most expensive
           // Note that there is an overhead for saving the reading and saving the cache file, so only use this loader to cache expensive loaders.
           // shouldUseCacheLoader && {
           //   loader: require.resolve('cache-loader'),
@@ -203,6 +196,13 @@ module.exports = function (webpackEnv) {
           //     cacheDirectory: paths.cacheLoaderDir,
           //   },
           // },
+          {
+            loader: require.resolve('resolve-url-loader'),
+            options: {
+              sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
+              root: paths.appSrc,
+            },
+          },
           {
             loader: require.resolve(preProcessor),
             options: {
@@ -734,8 +734,8 @@ module.exports = function (webpackEnv) {
               exclude: sassModuleRegex,
               use: getStyleLoaders(
                 {
-                  // When using sass-loader, the total count of loaders is up to 4 including cache-loader below the css-loader
-                  // When not using sass-loader, the total count of loaders is 3 not including cache-loader below the css-loader
+                  // When using cache-loader, the total count of loaders is up to 4 including cache-loader below the css-loader
+                  // When not using cache-loader, the total count of loaders is 3 not including cache-loader below the css-loader
                   // importLoaders: shouldUseCacheLoader ? 4 : 3,
                   importLoaders: 3,
                   sourceMap: isEnvProduction
@@ -771,8 +771,8 @@ module.exports = function (webpackEnv) {
               ],
               use: getStyleLoaders(
                 {
-                  // When using sass-loader, the total count of loaders is up to 4 including cache-loader below the css-loader
-                  // When not using sass-loader, the total count of loaders is 3 not including cache-loader below the css-loader
+                  // When using cache-loader, the total count of loaders is up to 4 including cache-loader below the css-loader
+                  // When not using cache-loader, the total count of loaders is 3 not including cache-loader below the css-loader
                   // importLoaders: shouldUseCacheLoader ? 4 : 3,
                   importLoaders: 3,
                   sourceMap: isEnvProduction


### PR DESCRIPTION
# Why

- Leopard has finally gotten the conclusion that we should use `cache-loader` with `git-restore-mtime`
- `cache-loader-hash` && `ci-cache-loader` are both not quite active and popular, we should still use `cache-loader`
- `cache-loader` above `resolve-url-loader` will generate small size of cache files, and it is faster to upload and download from `AWS S3`, it is also faster to read the cache files, so it can give us the best performance for speeding up build process.

# Experiments And Documents

- [Experiments To Use cache-loader](https://confluence.skyscannertools.net/display/LEOP/Experiments+To+Use+cache-loader)
- [Data From Using cache-loader-hash && ci-cache-loader](https://confluence.skyscannertools.net/pages/viewpage.action?pageId=541794241)
- [Comparison Of cache-loader && cache-loader-hash && ci-cache-loader](https://confluence.skyscannertools.net/pages/viewpage.action?pageId=541795963)