### PR TITLE
Uninstall typescript linting dependencies from react-scripts

### DIFF
--- a/packages/react-scripts/CHANGELOG.md
+++ b/packages/react-scripts/CHANGELOG.md
@@ -1,5 +1,10 @@
 # `backpack-react-scripts` Change Log
 
+
+## 9.4.0
+
+- Uninstall `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser`. These must now be provided either by directly installing them in your project or by an upcoming version of `eslint-config-skyscanner`.
+
 ## 9.3.2
 
 ### Fixed

--- a/packages/react-scripts/package-lock.json
+++ b/packages/react-scripts/package-lock.json
@@ -1,0 +1,15826 @@
+{
+  "name": "@skyscanner/backpack-react-scripts",
+  "version": "9.3.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.15.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/code-frame/-/code-frame-7.15.8.tgz",
+      "integrity": "sha1-RZkMR62tsAwDZ3uqiSIffMI9JQM=",
+      "requires": {
+        "@babel/highlight": "^7.14.5"
+      }
+    },
+    "@babel/compat-data": {
+      "version": "7.15.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/compat-data/-/compat-data-7.15.0.tgz",
+      "integrity": "sha1-Lbr4uFM0eWyvuw9Xk6kKL8AQsXY="
+    },
+    "@babel/core": {
+      "version": "7.12.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/core/-/core-7.12.3.tgz",
+      "integrity": "sha1-G0NohOHjv/b7EyjcArIIdZ3pKtg=",
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.12.1",
+        "@babel/helper-module-transforms": "^7.12.1",
+        "@babel/helpers": "^7.12.1",
+        "@babel/parser": "^7.12.3",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.19",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.15.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/generator/-/generator-7.15.8.tgz",
+      "integrity": "sha1-+la+a1lpUs6yMQSM+E7kmaGcDNE=",
+      "requires": {
+        "@babel/types": "^7.15.6",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz",
+      "integrity": "sha1-PQ5DsAxeSf22xX5CFgGnpljV+DU=",
+      "requires": {
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.15.4.tgz",
+      "integrity": "sha1-Ia2BX2CbhO4OMFhnbDPPbRZwUl8=",
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+      "integrity": "sha1-z22U8w++/BORI+J91rAvZa7tt7k=",
+      "requires": {
+        "@babel/compat-data": "^7.15.0",
+        "@babel/helper-validator-option": "^7.14.5",
+        "browserslist": "^4.16.6",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
+        }
+      }
+    },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.15.4.tgz",
+      "integrity": "sha1-f5d8F70SpfujY8sZvqCQOUvzfS4=",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-member-expression-to-functions": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4"
+      }
+    },
+    "@babel/helper-create-regexp-features-plugin": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.14.5.tgz",
+      "integrity": "sha1-x9WsXpz2IcJgV3Ivt6ikxYiTWMQ=",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.14.5",
+        "regexpu-core": "^4.7.1"
+      }
+    },
+    "@babel/helper-define-polyfill-provider": {
+      "version": "0.2.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz",
+      "integrity": "sha1-BSXt7FCUZTooJojTTYRuTHXpwLY=",
+      "requires": {
+        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/traverse": "^7.13.0",
+        "debug": "^4.1.1",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.14.2",
+        "semver": "^6.1.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
+        }
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.15.4.tgz",
+      "integrity": "sha1-+a7J0hnycer5K59WFZjKayaCYAw=",
+      "requires": {
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+      "integrity": "sha1-hFdE2vxDgaSl+2r6bD02+Yp4frw=",
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz",
+      "integrity": "sha1-CYgYk0oTf854tTaj4BWGS+Hih5s=",
+      "requires": {
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+      "integrity": "sha1-CZk6MlnA6Rj5nRBCYd/fwDPxeN8=",
+      "requires": {
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+      "integrity": "sha1-v9NNybupgkpGWLAxfsL9VxpR5u8=",
+      "requires": {
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+      "integrity": "sha1-4YAH0jBjLeoZtHhTuYRHbntOED8=",
+      "requires": {
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.15.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-module-transforms/-/helper-module-transforms-7.15.8.tgz",
+      "integrity": "sha1-2MDnWoelLjdKjyX4VRdHhqCUmLI=",
+      "requires": {
+        "@babel/helper-module-imports": "^7.15.4",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-simple-access": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.6"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz",
+      "integrity": "sha1-8xClEho7nMUtmrGRIr1ymCLe4XE=",
+      "requires": {
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+      "integrity": "sha1-WsgizpfuxGdBq3ClF5ceRDpwxak="
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.15.4.tgz",
+      "integrity": "sha1-JjfAcx5MkPv1isWLULK1oZL8lw8=",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.15.4",
+        "@babel/helper-wrap-function": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+      "integrity": "sha1-UqirJrqRjH9t7ihiiwcHGse3NHo=",
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+      "integrity": "sha1-rDaJBavx3o6XgUNLY12PhnS8wTs=",
+      "requires": {
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.15.4.tgz",
+      "integrity": "sha1-cH29uh9K0Po0+RFPyBl67H1dous=",
+      "requires": {
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+      "integrity": "sha1-rsq5Lc2+9qEKo7YqsgSwhfd24lc=",
+      "requires": {
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.15.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha1-Ig35k7/pBKSmsCq08zhaXr9uI4k="
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+      "integrity": "sha1-bnKh//GNXfy4eOHmLxoCHEty1aM="
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helper-wrap-function/-/helper-wrap-function-7.15.4.tgz",
+      "integrity": "sha1-b3VLJEbPrz1hJSPmq415wnw6Pec=",
+      "requires": {
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/helpers/-/helpers-7.15.4.tgz",
+      "integrity": "sha1-X0DwIFCjAnEho89I1JfAXFVer0M=",
+      "requires": {
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/highlight/-/highlight-7.14.5.tgz",
+      "integrity": "sha1-aGGlLwOWZAUAH2qlNKAaJNmejNk=",
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.14.5",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.15.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/parser/-/parser-7.15.8.tgz",
+      "integrity": "sha1-e6zcvnG9w/+TbVEMFdzqfPC5kBY="
+    },
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.15.4.tgz",
+      "integrity": "sha1-296rsegPYi2fC1g++ymZYF4KVn4=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.15.4",
+        "@babel/plugin-proposal-optional-chaining": "^7.14.5"
+      }
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.15.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.15.8.tgz",
+      "integrity": "sha1-oxAPeF+rQ1eYfEIjqxsCtZkEhAM=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-remap-async-to-generator": "^7.15.4",
+        "@babel/plugin-syntax-async-generators": "^7.8.4"
+      }
+    },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.14.5.tgz",
+      "integrity": "sha1-QNHuFAxbHjGjUPT17tlFCWVZtC4=",
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-proposal-class-static-block": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.15.4.tgz",
+      "integrity": "sha1-PnymEoRTwInotHepn5cMY/wcuNc=",
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.15.4",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5"
+      }
+    },
+    "@babel/plugin-proposal-decorators": {
+      "version": "7.12.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.12.1.tgz",
+      "integrity": "sha1-WScUOf7UFFRWxBBnRQVDruMy0V8=",
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.12.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-decorators": "^7.12.1"
+      }
+    },
+    "@babel/plugin-proposal-dynamic-import": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.14.5.tgz",
+      "integrity": "sha1-DGYX30YcDB+P/ztHzVl3I2AQHSw=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-export-namespace-from": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.14.5.tgz",
+      "integrity": "sha1-260kQxDObM0IMHIWfYzqg6Uvr3Y=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-json-strings": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.14.5.tgz",
+      "integrity": "sha1-ON5g2zYug6PYyUSshY3fnwwiOes=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-json-strings": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-logical-assignment-operators": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.14.5.tgz",
+      "integrity": "sha1-bmIpwqmbAqspFfglceDMZGpAxzg=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.14.5.tgz",
+      "integrity": "sha1-7jhYnOAOLMWbKZ7D6kBvzToP2vY=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-numeric-separator": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.14.5.tgz",
+      "integrity": "sha1-g2Mb8z2aUd8YTCECoGmsDFjAXxg=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.15.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.15.6.tgz",
+      "integrity": "sha1-72gFDIcD0Hslr0AsuWz380po7RE=",
+      "requires": {
+        "@babel/compat-data": "^7.15.0",
+        "@babel/helper-compilation-targets": "^7.15.4",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-transform-parameters": "^7.15.4"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.14.5.tgz",
+      "integrity": "sha1-k53W7d7/Omf997PwRLU0cmJZjDw=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.14.5.tgz",
+      "integrity": "sha1-+oNlHmCjYOPxN5fu8AuNUZaVtgM=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.14.5",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-private-methods": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.14.5.tgz",
+      "integrity": "sha1-N0RklZlrKUXzD1vltg1eKqT1eS0=",
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.15.4.tgz",
+      "integrity": "sha1-VcXjtNAmH9RP5jfj9iTPsPSE4+U=",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.15.4",
+        "@babel/helper-create-class-features-plugin": "^7.15.4",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.14.5.tgz",
+      "integrity": "sha1-D5XuDnV6XWR/N42qDsp+k/qou+g=",
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha1-qYP7Gusuw/btBCohD2QOkOeG/g0=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha1-TJpvZp9dDN8bkKFnHpoUa+UwDOo=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha1-tcmHJ0xKOoK4lxR5aTGmtTVErhA=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      }
+    },
+    "@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha1-GV34mxRrS3izv4l/16JXyEZZ1AY=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-decorators": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.14.5.tgz",
+      "integrity": "sha1-6vucDL4JyK/rlkujp7vWOUWnLyA=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha1-Yr+Ysto80h1iYVT8lu5bPLaOrLM=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-export-namespace-from": {
+      "version": "7.8.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+      "integrity": "sha1-AolkqbqA28CUyRXEh618TnpmRlo=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-syntax-flow": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.14.5.tgz",
+      "integrity": "sha1-L/ZUmZSX19fRQkkyYABSY3MdoYA=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha1-7mATSMNw+jNNIge+FYd3SWUh/VE=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha1-AcohtmjNghjJ5kDLbdiMVBKyyWo=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
+      "integrity": "sha1-AA4uJdhnPM5JMAUXo+2kTCY+QgE=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha1-ypHvRjA1MESLkGZSusLp/plB9pk=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha1-Fn7XA2iIYIH3S1w2xlqIwDtm0ak=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha1-ubBws+M1cM2f0Hun+pHA3Te5r5c=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha1-YOIl7cvZimQDMqLnLdPmbxr1WHE=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha1-YRGiZbz7Ag6579D9/X0mQCue1sE=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha1-T2nCq5UWfgGAzVM2YT+MV4j31Io=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha1-DcZnHsDqIrbpShEU+FeXDNOd4a0=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha1-wc/a3DWmRiQAAfBhOCR7dBw02Uw=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.14.5.tgz",
+      "integrity": "sha1-uCxs5HGxZbXOQgz5KRTW+0YiVxY=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.14.5.tgz",
+      "integrity": "sha1-9xh9lYinaN0IC/TJ/+EX6mL3hio=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.14.5.tgz",
+      "integrity": "sha1-cseJCE2PIJSsuUVjOUPvhEPTnmc=",
+      "requires": {
+        "@babel/helper-module-imports": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-remap-async-to-generator": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.14.5.tgz",
+      "integrity": "sha1-5IZB2ZnUvBV6Z+8zautUvET9OtQ=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.15.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.15.3.tgz",
+      "integrity": "sha1-lMgabi/CMLzObvU3rJah5NKzr68=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.15.4.tgz",
+      "integrity": "sha1-UK7heq9/MyrkTjvOTC4QU01dO/E=",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-optimise-call-expression": "^7.15.4",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-replace-supers": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "globals": "^11.1.0"
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.14.5.tgz",
+      "integrity": "sha1-G514mHQg0RIj1BGVRhzEO5dLIE8=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.14.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.14.7.tgz",
+      "integrity": "sha1-CtWO034j4iCE0QnxhSYINeVVdXY=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.14.5.tgz",
+      "integrity": "sha1-L2v3bka9+AQ7Tn4WzyRTJim6DHo=",
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.14.5.tgz",
+      "integrity": "sha1-NlpIRIgb3xUB46nwJw5/D5EXeVQ=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.14.5.tgz",
+      "integrity": "sha1-UVS43Wo9/m2Qkj1hckvT3uuQtJM=",
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-flow-strip-types": {
+      "version": "7.12.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.12.1.tgz",
+      "integrity": "sha1-hDDez6frKupUFO1KP6bhZSt9d8Q=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-flow": "^7.12.1"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.15.4.tgz",
+      "integrity": "sha1-JcYszicYz7KXFfQW511SY/s2qMI=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.14.5.tgz",
+      "integrity": "sha1-6Bxl7LkAdG1/MYAva+0fUtkV1vI=",
+      "requires": {
+        "@babel/helper-function-name": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-literals/-/plugin-transform-literals-7.14.5.tgz",
+      "integrity": "sha1-QdBsf/XU0J489Fh70+zzkwxzD3g=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.14.5.tgz",
+      "integrity": "sha1-s5zVISor8jWmF9Mg7CtIvMCRuKc=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.14.5.tgz",
+      "integrity": "sha1-T9nOfjQRy4uDhISAtwQdgwBIWPc=",
+      "requires": {
+        "@babel/helper-module-transforms": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.15.4.tgz",
+      "integrity": "sha1-ggEQEkDqu1p2wI72GylU92e2tME=",
+      "requires": {
+        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-simple-access": "^7.15.4",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.15.4.tgz",
+      "integrity": "sha1-tCiQxzSaeMgncZ8dLQzTjH0mgTI=",
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.15.4",
+        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.14.5.tgz",
+      "integrity": "sha1-+2Yt/uaXzOJ0p82lJRkKeQlqpuA=",
+      "requires": {
+        "@babel/helper-module-transforms": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.14.9",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.14.9.tgz",
+      "integrity": "sha1-xo9cXRLS66ujdi5XwsT2NHpG57I=",
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.14.5.tgz",
+      "integrity": "sha1-Mb2ui5JdyEB26/zSqZQBQ67X2/g=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.14.5.tgz",
+      "integrity": "sha1-0LX66snphZehYanPeMUn7ZNM3EU=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-replace-supers": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.15.4.tgz",
+      "integrity": "sha1-XyKFzDFgv0jIUCQycWtIUE0p7WI=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.14.5.tgz",
+      "integrity": "sha1-DduqH4PbNgbxzfSEb6HftHNFizQ=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-react-constant-elements": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.14.5.tgz",
+      "integrity": "sha1-QXkNhW98XOyC0rz10OUGTWglIu0=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-react-display-name": {
+      "version": "7.15.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.15.1.tgz",
+      "integrity": "sha1-aqrGCZ8fz2WJ01rmvhtuEMjGArk=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-react-jsx": {
+      "version": "7.14.9",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.9.tgz",
+      "integrity": "sha1-MxSyFjAzq6xSAKhpxN4kLNUKkUw=",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.14.5",
+        "@babel/helper-module-imports": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-jsx": "^7.14.5",
+        "@babel/types": "^7.14.9"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-development": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.14.5.tgz",
+      "integrity": "sha1-Gmxz4vftLELuvD0q1gsMdJT8ua8=",
+      "requires": {
+        "@babel/plugin-transform-react-jsx": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-self": {
+      "version": "7.14.9",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.14.9.tgz",
+      "integrity": "sha1-MwQeZlRTOR627lSi7PO6HUa9MPQ=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-react-jsx-source": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.14.5.tgz",
+      "integrity": "sha1-efco5g5tvTGiuGCwv2yXZZGKzx0=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-react-pure-annotations": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.14.5.tgz",
+      "integrity": "sha1-GN5hK4QCHjqYAsvCEsnZ9G0NEfw=",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.14.5.tgz",
+      "integrity": "sha1-lnb9VwftKPUicnxbPAqoVERAsE8=",
+      "requires": {
+        "regenerator-transform": "^0.14.2"
+      }
+    },
+    "@babel/plugin-transform-reserved-words": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.14.5.tgz",
+      "integrity": "sha1-xEWJtmHP2++NQwDcx0ad/6kvgwQ=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.12.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.1.tgz",
+      "integrity": "sha1-BLeSBX60YDif9qQZjjd2FOoee6U=",
+      "requires": {
+        "@babel/helper-module-imports": "^7.12.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
+        }
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.14.5.tgz",
+      "integrity": "sha1-l/E4VfFAkzjYyty6ymcK154JGlg=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.15.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-spread/-/plugin-transform-spread-7.15.8.tgz",
+      "integrity": "sha1-edWqJ/aNcARJstoHaR36MtL21Gg=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.15.4"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.14.5.tgz",
+      "integrity": "sha1-W2F1Qmdei3dhKUOB88KMYz9Arrk=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.14.5.tgz",
+      "integrity": "sha1-pfK8Izk32EU4hdxza92Nn/q/PZM=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.14.5.tgz",
+      "integrity": "sha1-Oa8nOemJor0pG/a1PxaYFCPUV9Q=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.15.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.15.8.tgz",
+      "integrity": "sha1-/w5qR96bLVhlISOrWoebL/IGZdg=",
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.15.4",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-typescript": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-unicode-escapes": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.14.5.tgz",
+      "integrity": "sha1-nUvSpoHjxdes9PV/qeURddkdDGs=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.14.5.tgz",
+      "integrity": "sha1-TNCbbIQl3YElXHzrP7GDbnQUOC4=",
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.15.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/preset-env/-/preset-env-7.15.8.tgz",
+      "integrity": "sha1-9SfOW8sSHNGZ9rUCvyPkILP/jbo=",
+      "requires": {
+        "@babel/compat-data": "^7.15.0",
+        "@babel/helper-compilation-targets": "^7.15.4",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.15.4",
+        "@babel/plugin-proposal-async-generator-functions": "^7.15.8",
+        "@babel/plugin-proposal-class-properties": "^7.14.5",
+        "@babel/plugin-proposal-class-static-block": "^7.15.4",
+        "@babel/plugin-proposal-dynamic-import": "^7.14.5",
+        "@babel/plugin-proposal-export-namespace-from": "^7.14.5",
+        "@babel/plugin-proposal-json-strings": "^7.14.5",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.14.5",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.5",
+        "@babel/plugin-proposal-numeric-separator": "^7.14.5",
+        "@babel/plugin-proposal-object-rest-spread": "^7.15.6",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.14.5",
+        "@babel/plugin-proposal-optional-chaining": "^7.14.5",
+        "@babel/plugin-proposal-private-methods": "^7.14.5",
+        "@babel/plugin-proposal-private-property-in-object": "^7.15.4",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.14.5",
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5",
+        "@babel/plugin-transform-arrow-functions": "^7.14.5",
+        "@babel/plugin-transform-async-to-generator": "^7.14.5",
+        "@babel/plugin-transform-block-scoped-functions": "^7.14.5",
+        "@babel/plugin-transform-block-scoping": "^7.15.3",
+        "@babel/plugin-transform-classes": "^7.15.4",
+        "@babel/plugin-transform-computed-properties": "^7.14.5",
+        "@babel/plugin-transform-destructuring": "^7.14.7",
+        "@babel/plugin-transform-dotall-regex": "^7.14.5",
+        "@babel/plugin-transform-duplicate-keys": "^7.14.5",
+        "@babel/plugin-transform-exponentiation-operator": "^7.14.5",
+        "@babel/plugin-transform-for-of": "^7.15.4",
+        "@babel/plugin-transform-function-name": "^7.14.5",
+        "@babel/plugin-transform-literals": "^7.14.5",
+        "@babel/plugin-transform-member-expression-literals": "^7.14.5",
+        "@babel/plugin-transform-modules-amd": "^7.14.5",
+        "@babel/plugin-transform-modules-commonjs": "^7.15.4",
+        "@babel/plugin-transform-modules-systemjs": "^7.15.4",
+        "@babel/plugin-transform-modules-umd": "^7.14.5",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.14.9",
+        "@babel/plugin-transform-new-target": "^7.14.5",
+        "@babel/plugin-transform-object-super": "^7.14.5",
+        "@babel/plugin-transform-parameters": "^7.15.4",
+        "@babel/plugin-transform-property-literals": "^7.14.5",
+        "@babel/plugin-transform-regenerator": "^7.14.5",
+        "@babel/plugin-transform-reserved-words": "^7.14.5",
+        "@babel/plugin-transform-shorthand-properties": "^7.14.5",
+        "@babel/plugin-transform-spread": "^7.15.8",
+        "@babel/plugin-transform-sticky-regex": "^7.14.5",
+        "@babel/plugin-transform-template-literals": "^7.14.5",
+        "@babel/plugin-transform-typeof-symbol": "^7.14.5",
+        "@babel/plugin-transform-unicode-escapes": "^7.14.5",
+        "@babel/plugin-transform-unicode-regex": "^7.14.5",
+        "@babel/preset-modules": "^0.1.4",
+        "@babel/types": "^7.15.6",
+        "babel-plugin-polyfill-corejs2": "^0.2.2",
+        "babel-plugin-polyfill-corejs3": "^0.2.5",
+        "babel-plugin-polyfill-regenerator": "^0.2.2",
+        "core-js-compat": "^3.16.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
+        }
+      }
+    },
+    "@babel/preset-modules": {
+      "version": "0.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
+      "integrity": "sha1-Ni8raMZihClw/bXiVP/I/BwuQV4=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+        "@babel/plugin-transform-dotall-regex": "^7.4.4",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      }
+    },
+    "@babel/preset-react": {
+      "version": "7.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/preset-react/-/preset-react-7.14.5.tgz",
+      "integrity": "sha1-D7t2lRP4mcLFbzqIL6eWc8LUqzw=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-transform-react-display-name": "^7.14.5",
+        "@babel/plugin-transform-react-jsx": "^7.14.5",
+        "@babel/plugin-transform-react-jsx-development": "^7.14.5",
+        "@babel/plugin-transform-react-pure-annotations": "^7.14.5"
+      }
+    },
+    "@babel/preset-typescript": {
+      "version": "7.12.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/preset-typescript/-/preset-typescript-7.12.1.tgz",
+      "integrity": "sha1-hkgLSDu5f3UDbohk/kBMx4LMMRs=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-transform-typescript": "^7.12.1"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/runtime/-/runtime-7.15.4.tgz",
+      "integrity": "sha1-/RfRa/34eObdAtGXU6OfqKjZyEo=",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@babel/template": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/template/-/template-7.15.4.tgz",
+      "integrity": "sha1-UYmNNdzz+qZwxO5q/P1RfuE58ZQ=",
+      "requires": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.15.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/traverse/-/traverse-7.15.4.tgz",
+      "integrity": "sha1-/4UQNnoUS/v/VS2eGOKPPiiJwi0=",
+      "requires": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-function-name": "^7.15.4",
+        "@babel/helper-hoist-variables": "^7.15.4",
+        "@babel/helper-split-export-declaration": "^7.15.4",
+        "@babel/parser": "^7.15.4",
+        "@babel/types": "^7.15.4",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      }
+    },
+    "@babel/types": {
+      "version": "7.15.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/types/-/types-7.15.6.tgz",
+      "integrity": "sha1-mavcSCGLKIHAWN0KerBbmcm+dY8=",
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha1-daLotRy3WKdVPWgEpZMteqznXDk="
+    },
+    "@cnakazawa/watch": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@cnakazawa/watch/-/watch-1.0.4.tgz",
+      "integrity": "sha1-+GSuhQBND8q29QvpFBxNo2jRZWo=",
+      "requires": {
+        "exec-sh": "^0.3.2",
+        "minimist": "^1.2.0"
+      }
+    },
+    "@csstools/convert-colors": {
+      "version": "1.4.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
+      "integrity": "sha1-rUldxBsS511YjG24uYNPCPoTHrc="
+    },
+    "@csstools/normalize.css": {
+      "version": "10.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
+      "integrity": "sha1-8JULuhiBlRLUL3GX5WxRiqSRzxg="
+    },
+    "@gar/promisify": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@gar/promisify/-/promisify-1.1.2.tgz",
+      "integrity": "sha1-MKqCXxHUOGcdWFvUTn/VZFNfwhA="
+    },
+    "@hapi/address": {
+      "version": "2.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@hapi/address/-/address-2.1.4.tgz",
+      "integrity": "sha1-XWftQ/P9QaadS5/3tW58DR0KgeU="
+    },
+    "@hapi/bourne": {
+      "version": "1.3.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha1-CnCVreoGckPOMoPhtWuKj0U7JCo="
+    },
+    "@hapi/hoek": {
+      "version": "8.5.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha1-/elgZMpEbeyMVajC8TCVewcMbgY="
+    },
+    "@hapi/joi": {
+      "version": "15.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@hapi/joi/-/joi-15.1.1.tgz",
+      "integrity": "sha1-xnW4pxKW8Cgz+NbSQ7NMV7jOGdc=",
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/topo": {
+      "version": "3.1.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@hapi/topo/-/topo-3.1.6.tgz",
+      "integrity": "sha1-aNk1+j6uf91asNf5U/MgXYsr/Ck=",
+      "requires": {
+        "@hapi/hoek": "^8.3.0"
+      }
+    },
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha1-/T2x1Z7PfPEh6AZQu4ZxL5tV7O0=",
+      "requires": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk="
+        }
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha1-5F44TkuOwWvOL9kDr3hFD2v37Jg="
+    },
+    "@jest/console": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@jest/console/-/console-26.6.2.tgz",
+      "integrity": "sha1-TgS8RkAUNYsDq0k3gF7jagrrmPI=",
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jest/core": {
+      "version": "26.6.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@jest/core/-/core-26.6.3.tgz",
+      "integrity": "sha1-djn8s4M9dIpGVq2lS94ZMFHkX60=",
+      "requires": {
+        "@jest/console": "^26.6.2",
+        "@jest/reporters": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.4",
+        "jest-changed-files": "^26.6.2",
+        "jest-config": "^26.6.3",
+        "jest-haste-map": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-regex-util": "^26.0.0",
+        "jest-resolve": "^26.6.2",
+        "jest-resolve-dependencies": "^26.6.3",
+        "jest-runner": "^26.6.3",
+        "jest-runtime": "^26.6.3",
+        "jest-snapshot": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-validate": "^26.6.2",
+        "jest-watcher": "^26.6.2",
+        "micromatch": "^4.0.2",
+        "p-each-series": "^2.1.0",
+        "rimraf": "^3.0.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "jest-resolve": {
+          "version": "26.6.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-resolve/-/jest-resolve-26.6.2.tgz",
+          "integrity": "sha1-o6sVFyF/RptQTxtWYDxbtUH7tQc=",
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "jest-pnp-resolver": "^1.2.2",
+            "jest-util": "^26.6.2",
+            "read-pkg-up": "^7.0.1",
+            "resolve": "^1.18.1",
+            "slash": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jest/environment": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@jest/environment/-/environment-26.6.2.tgz",
+      "integrity": "sha1-ujZMxy4iHnnMjwqZVVv111d8+Sw=",
+      "requires": {
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "jest-mock": "^26.6.2"
+      }
+    },
+    "@jest/fake-timers": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@jest/fake-timers/-/fake-timers-26.6.2.tgz",
+      "integrity": "sha1-RZwym89wzuSvTX4/PmeEgSNTWq0=",
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@types/node": "*",
+        "jest-message-util": "^26.6.2",
+        "jest-mock": "^26.6.2",
+        "jest-util": "^26.6.2"
+      }
+    },
+    "@jest/globals": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@jest/globals/-/globals-26.6.2.tgz",
+      "integrity": "sha1-W2E7eKGqJlWukI66Y4zJaiDfcgo=",
+      "requires": {
+        "@jest/environment": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "expect": "^26.6.2"
+      }
+    },
+    "@jest/reporters": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@jest/reporters/-/reporters-26.6.2.tgz",
+      "integrity": "sha1-H1GLmWN6Xxgwe9Ps+SdfaIKmZ/Y=",
+      "requires": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.2.4",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.3",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.2",
+        "jest-haste-map": "^26.6.2",
+        "jest-resolve": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-worker": "^26.6.2",
+        "node-notifier": "^8.0.0",
+        "slash": "^3.0.0",
+        "source-map": "^0.6.0",
+        "string-length": "^4.0.1",
+        "terminal-link": "^2.0.0",
+        "v8-to-istanbul": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "istanbul-lib-instrument": {
+          "version": "4.0.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+          "integrity": "sha1-hzxv/4l0UBGCIndGlqPyiQLXfB0=",
+          "requires": {
+            "@babel/core": "^7.7.5",
+            "@istanbuljs/schema": "^0.1.2",
+            "istanbul-lib-coverage": "^3.0.0",
+            "semver": "^6.3.0"
+          }
+        },
+        "jest-resolve": {
+          "version": "26.6.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-resolve/-/jest-resolve-26.6.2.tgz",
+          "integrity": "sha1-o6sVFyF/RptQTxtWYDxbtUH7tQc=",
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "jest-pnp-resolver": "^1.2.2",
+            "jest-util": "^26.6.2",
+            "read-pkg-up": "^7.0.1",
+            "resolve": "^1.18.1",
+            "slash": "^3.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jest/source-map": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@jest/source-map/-/source-map-26.6.2.tgz",
+      "integrity": "sha1-Ka9eHi4yTK/MyTbyGDCfVKtp1TU=",
+      "requires": {
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.4",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        }
+      }
+    },
+    "@jest/test-result": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@jest/test-result/-/test-result-26.6.2.tgz",
+      "integrity": "sha1-VdpYti3xNFdsyVR276X3lJ4/Xxg=",
+      "requires": {
+        "@jest/console": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      }
+    },
+    "@jest/test-sequencer": {
+      "version": "26.6.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@jest/test-sequencer/-/test-sequencer-26.6.3.tgz",
+      "integrity": "sha1-mOikUQCGOIbQdCBej/3Fp+tYKxc=",
+      "requires": {
+        "@jest/test-result": "^26.6.2",
+        "graceful-fs": "^4.2.4",
+        "jest-haste-map": "^26.6.2",
+        "jest-runner": "^26.6.3",
+        "jest-runtime": "^26.6.3"
+      }
+    },
+    "@jest/transform": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@jest/transform/-/transform-26.6.2.tgz",
+      "integrity": "sha1-WsV8X6GtF7Kq6D5z5FgTiU3PLks=",
+      "requires": {
+        "@babel/core": "^7.1.0",
+        "@jest/types": "^26.6.2",
+        "babel-plugin-istanbul": "^6.0.0",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^1.4.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graceful-fs": "^4.2.4",
+        "jest-haste-map": "^26.6.2",
+        "jest-regex-util": "^26.0.0",
+        "jest-util": "^26.6.2",
+        "micromatch": "^4.0.2",
+        "pirates": "^4.0.1",
+        "slash": "^3.0.0",
+        "source-map": "^0.6.1",
+        "write-file-atomic": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jest/types": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@jest/types/-/types-26.6.2.tgz",
+      "integrity": "sha1-vvWlMgMOHYii9abZM/hOlyJu1I4=",
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos="
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@npmcli/fs": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@npmcli/fs/-/fs-1.0.0.tgz",
+      "integrity": "sha1-WJYSz606bqD+r8uQHSnGP9UtsJ8=",
+      "requires": {
+        "@gar/promisify": "^1.0.1",
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "@npmcli/move-file": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@npmcli/move-file/-/move-file-1.1.2.tgz",
+      "integrity": "sha1-GoLD43L3yuklPrZtclQ9a4aFxnQ=",
+      "requires": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34="
+        }
+      }
+    },
+    "@pmmmwh/react-refresh-webpack-plugin": {
+      "version": "0.4.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz",
+      "integrity": "sha1-HuxGBZbSAMAja/GVsHil0d+Jt2Y=",
+      "requires": {
+        "ansi-html": "^0.0.7",
+        "error-stack-parser": "^2.0.6",
+        "html-entities": "^1.2.1",
+        "native-url": "^0.2.6",
+        "schema-utils": "^2.6.5",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M="
+        }
+      }
+    },
+    "@rollup/plugin-node-resolve": {
+      "version": "7.1.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
+      "integrity": "sha1-gN44Tt+9e/yRARZJEPhgeBUaPso=",
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8",
+        "@types/resolve": "0.0.8",
+        "builtin-modules": "^3.1.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.14.2"
+      }
+    },
+    "@rollup/plugin-replace": {
+      "version": "2.4.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@rollup/plugin-replace/-/plugin-replace-2.4.2.tgz",
+      "integrity": "sha1-otU5MU+8d8JEhY+qUjASglBoUQo=",
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "magic-string": "^0.25.7"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha1-cGtFJO5tyLEDs8mVUz5a1oDAK5s=",
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      }
+    },
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha1-OALd0hpQqUm2ch3dcto25n5/Gy0=",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha1-KTZ0/MsyYqx4LHqt/eyoaxDHXEA=",
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@skyscanner/bpk-foundations-common": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-1.0.0.tgz",
+      "integrity": "sha1-eYDpslIl9VdePjB76Rfy/v3/X4A=",
+      "requires": {
+        "color": "^3.0.0"
+      }
+    },
+    "@skyscanner/bpk-foundations-web": {
+      "version": "1.2.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@skyscanner/bpk-foundations-web/-/bpk-foundations-web-1.2.1.tgz",
+      "integrity": "sha1-sWLeJGZAtF7ymyMuxxTG0ZTg2W4=",
+      "requires": {
+        "@skyscanner/bpk-foundations-common": "^1.0.0",
+        "color": "^3.0.0"
+      }
+    },
+    "@skyscanner/bpk-svgs": {
+      "version": "12.7.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@skyscanner/bpk-svgs/-/bpk-svgs-12.7.3.tgz",
+      "integrity": "sha1-wci9dIGp81i9OD2KCHqOxxxeZTU="
+    },
+    "@surma/rollup-plugin-off-main-thread": {
+      "version": "1.4.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-1.4.2.tgz",
+      "integrity": "sha1-5nhravV5n4L3qzqC5T9hgtK5Glg=",
+      "requires": {
+        "ejs": "^2.6.1",
+        "magic-string": "^0.25.0"
+      }
+    },
+    "@svgr/babel-plugin-add-jsx-attribute": {
+      "version": "5.4.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-5.4.0.tgz",
+      "integrity": "sha1-ge9hlHuyaOudUFI0RvnGOPs1WQY="
+    },
+    "@svgr/babel-plugin-remove-jsx-attribute": {
+      "version": "5.4.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-5.4.0.tgz",
+      "integrity": "sha1-ayx3DJXIdGVP1eHV70dbeKCpYu8="
+    },
+    "@svgr/babel-plugin-remove-jsx-empty-expression": {
+      "version": "5.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-5.0.1.tgz",
+      "integrity": "sha1-JWIaiRXtetcNps6j0KbbwuqTPv0="
+    },
+    "@svgr/babel-plugin-replace-jsx-attribute-value": {
+      "version": "5.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-5.0.1.tgz",
+      "integrity": "sha1-CyIfxX+fzRDpH+IZ4s0N0DFFqJc="
+    },
+    "@svgr/babel-plugin-svg-dynamic-title": {
+      "version": "5.4.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-5.4.0.tgz",
+      "integrity": "sha1-E5tUbdDDGGtuXbT+/CbLC66nKdc="
+    },
+    "@svgr/babel-plugin-svg-em-dimensions": {
+      "version": "5.4.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-5.4.0.tgz",
+      "integrity": "sha1-ZUP2lSZjKhM85cq6uWXe6uoiNKA="
+    },
+    "@svgr/babel-plugin-transform-react-native-svg": {
+      "version": "5.4.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-5.4.0.tgz",
+      "integrity": "sha1-AL+aenPxytOUjNqx+N+3dHUPjIA="
+    },
+    "@svgr/babel-plugin-transform-svg-component": {
+      "version": "5.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-5.5.0.tgz",
+      "integrity": "sha1-WDpeKhk+IU2i86/rC56NMlASa0o="
+    },
+    "@svgr/babel-preset": {
+      "version": "5.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@svgr/babel-preset/-/babel-preset-5.5.0.tgz",
+      "integrity": "sha1-ivVPPgqK3XseKw/NWogsVTk98yc=",
+      "requires": {
+        "@svgr/babel-plugin-add-jsx-attribute": "^5.4.0",
+        "@svgr/babel-plugin-remove-jsx-attribute": "^5.4.0",
+        "@svgr/babel-plugin-remove-jsx-empty-expression": "^5.0.1",
+        "@svgr/babel-plugin-replace-jsx-attribute-value": "^5.0.1",
+        "@svgr/babel-plugin-svg-dynamic-title": "^5.4.0",
+        "@svgr/babel-plugin-svg-em-dimensions": "^5.4.0",
+        "@svgr/babel-plugin-transform-react-native-svg": "^5.4.0",
+        "@svgr/babel-plugin-transform-svg-component": "^5.5.0"
+      }
+    },
+    "@svgr/core": {
+      "version": "5.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@svgr/core/-/core-5.5.0.tgz",
+      "integrity": "sha1-gugmuHFdcQgxIP6PJJLsfXh0pXk=",
+      "requires": {
+        "@svgr/plugin-jsx": "^5.5.0",
+        "camelcase": "^6.2.0",
+        "cosmiconfig": "^7.0.0"
+      }
+    },
+    "@svgr/hast-util-to-babel-ast": {
+      "version": "5.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-5.5.0.tgz",
+      "integrity": "sha1-XuUqnCUz9z5j+PIrd5+TzUMqVGE=",
+      "requires": {
+        "@babel/types": "^7.12.6"
+      }
+    },
+    "@svgr/plugin-jsx": {
+      "version": "5.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@svgr/plugin-jsx/-/plugin-jsx-5.5.0.tgz",
+      "integrity": "sha1-GqjNeYodtxc6wENGbXtSI2s2kAA=",
+      "requires": {
+        "@babel/core": "^7.12.3",
+        "@svgr/babel-preset": "^5.5.0",
+        "@svgr/hast-util-to-babel-ast": "^5.5.0",
+        "svg-parser": "^2.0.2"
+      }
+    },
+    "@svgr/plugin-svgo": {
+      "version": "5.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@svgr/plugin-svgo/-/plugin-svgo-5.5.0.tgz",
+      "integrity": "sha1-AtpV2FMgVJMk4gHHsuU79DH8wkY=",
+      "requires": {
+        "cosmiconfig": "^7.0.0",
+        "deepmerge": "^4.2.2",
+        "svgo": "^1.2.2"
+      }
+    },
+    "@svgr/webpack": {
+      "version": "5.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@svgr/webpack/-/webpack-5.5.0.tgz",
+      "integrity": "sha1-quhY7lefX6jObDFm71bGobOBtkA=",
+      "requires": {
+        "@babel/core": "^7.12.3",
+        "@babel/plugin-transform-react-constant-elements": "^7.12.1",
+        "@babel/preset-env": "^7.12.1",
+        "@babel/preset-react": "^7.12.5",
+        "@svgr/core": "^5.5.0",
+        "@svgr/plugin-jsx": "^5.5.0",
+        "@svgr/plugin-svgo": "^5.5.0",
+        "loader-utils": "^2.0.0"
+      }
+    },
+    "@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha1-zLkURTYBeaBOf+av94wA/8Hur4I="
+    },
+    "@types/babel__core": {
+      "version": "7.1.16",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/babel__core/-/babel__core-7.1.16.tgz",
+      "integrity": "sha1-vBLHS31l6C0ph2tdC69cYlrFhwI=",
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "@types/babel__generator": {
+      "version": "7.6.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/babel__generator/-/babel__generator-7.6.3.tgz",
+      "integrity": "sha1-9Fa0ss55E392iqEw0kI9LwzPq6U=",
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__template": {
+      "version": "7.4.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/babel__template/-/babel__template-7.4.1.tgz",
+      "integrity": "sha1-PRpI/Z1sDt/Vby/1eNrtSPNsiWk=",
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__traverse": {
+      "version": "7.14.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/babel__traverse/-/babel__traverse-7.14.2.tgz",
+      "integrity": "sha1-/81HC7s/i/MEgWePtVAieMqDOkM=",
+      "requires": {
+        "@babel/types": "^7.3.0"
+      }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha1-4Xfmme4bjCLSMXTKqnQiZEOJUJ8="
+    },
+    "@types/glob": {
+      "version": "7.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha1-vBtb86qS8lvV3TnzXFc2G9zlsus=",
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/graceful-fs": {
+      "version": "4.1.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
+      "integrity": "sha1-If+6DZjaQ1DbZIkfkqnl2zzbThU=",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/html-minifier-terser": {
+      "version": "5.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz",
+      "integrity": "sha1-aTsxatMj6pfu1rOO0aPMArFnK1c="
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha1-S6jdtyAiH0MuRDvV+RF/0iz9R2I="
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha1-wUwk8Y6oGQwRjudWK3/5mjZVJoY=",
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
+      "integrity": "sha1-kVP+mLuivVZaY63ZQ21vDX+EaP8=",
+      "requires": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/json-schema": {
+      "version": "7.0.9",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/json-schema/-/json-schema-7.0.9.tgz",
+      "integrity": "sha1-l+3JA36gw4WFMgsolk3eOznkZg0="
+    },
+    "@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha1-EAHMXmo3BLg8I2An538vWOoBD0A="
+    },
+    "@types/node": {
+      "version": "16.11.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/node/-/node-16.11.1.tgz",
+      "integrity": "sha1-LlCmSaUPxANDOhT4Ke+s4aNEPpc="
+    },
+    "@types/normalize-package-data": {
+      "version": "2.4.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha1-0zV0eaD9/dWQf+Z+F+CoXJBuEwE="
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-L4u0QUNNFjs1+4/9zNcTiSf/uMA="
+    },
+    "@types/prettier": {
+      "version": "2.4.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha1-4TAwSNU4lWPhMPW92J03qZrLdes="
+    },
+    "@types/q": {
+      "version": "1.5.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/q/-/q-1.5.5.tgz",
+      "integrity": "sha1-daKo59irSyMEFFBdkjNdHctTpt8="
+    },
+    "@types/resolve": {
+      "version": "0.0.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/resolve/-/resolve-0.0.8.tgz",
+      "integrity": "sha1-8mB00jjgJlnjI84aE9BB7uKA4ZQ=",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/source-list-map": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/source-list-map/-/source-list-map-0.1.2.tgz",
+      "integrity": "sha1-AHiDYGP/rxdBI0m7o2QIfgrALsk="
+    },
+    "@types/stack-utils": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/stack-utils/-/stack-utils-2.0.1.tgz",
+      "integrity": "sha1-IPGClPeX8iCbX2XI47XI6CYdEnw="
+    },
+    "@types/tapable": {
+      "version": "1.0.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/tapable/-/tapable-1.0.8.tgz",
+      "integrity": "sha1-uUpDkchWZse3Mpn9OtedT6pDUxA="
+    },
+    "@types/uglify-js": {
+      "version": "3.13.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/uglify-js/-/uglify-js-3.13.1.tgz",
+      "integrity": "sha1-XoienoHpQkXHW2RQYA4cXqKHiuo=",
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        }
+      }
+    },
+    "@types/webpack": {
+      "version": "4.41.31",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/webpack/-/webpack-4.41.31.tgz",
+      "integrity": "sha1-w18lKjVZ3fnIXA2LC0IBkCXlgao=",
+      "requires": {
+        "@types/node": "*",
+        "@types/tapable": "^1",
+        "@types/uglify-js": "*",
+        "@types/webpack-sources": "*",
+        "anymatch": "^3.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        }
+      }
+    },
+    "@types/webpack-sources": {
+      "version": "3.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/webpack-sources/-/webpack-sources-3.2.0.tgz",
+      "integrity": "sha1-FtdZuglsKJA0smVT0t8b9FJI04s=",
+      "requires": {
+        "@types/node": "*",
+        "@types/source-list-map": "*",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M="
+        }
+      }
+    },
+    "@types/yargs": {
+      "version": "15.0.14",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/yargs/-/yargs-15.0.14.tgz",
+      "integrity": "sha1-Jtgh3biecEkhYLZtEKDrbfj2+wY=",
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "20.2.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
+      "integrity": "sha1-O5ziSJkZ2eT+pDm3aRarw0st8Sk="
+    },
+    "@webassemblyjs/ast": {
+      "version": "1.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@webassemblyjs/ast/-/ast-1.9.0.tgz",
+      "integrity": "sha1-vYUGBLQEJFmlpBzX0zjL7Wle2WQ=",
+      "requires": {
+        "@webassemblyjs/helper-module-context": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/wast-parser": "1.9.0"
+      }
+    },
+    "@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz",
+      "integrity": "sha1-PD07Jxvd/ITesA9xNEQ4MR1S/7Q="
+    },
+    "@webassemblyjs/helper-api-error": {
+      "version": "1.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
+      "integrity": "sha1-ID9nbjM7lsnaLuqzzO8zxFkotqI="
+    },
+    "@webassemblyjs/helper-buffer": {
+      "version": "1.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
+      "integrity": "sha1-oUQtJpxf6yP8vJ73WdrDVH8p3gA="
+    },
+    "@webassemblyjs/helper-code-frame": {
+      "version": "1.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz",
+      "integrity": "sha1-ZH+Iks0gQ6gqwMjF51w28dkVnyc=",
+      "requires": {
+        "@webassemblyjs/wast-printer": "1.9.0"
+      }
+    },
+    "@webassemblyjs/helper-fsm": {
+      "version": "1.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz",
+      "integrity": "sha1-wFJWtxJEIUZx9LCOwQitY7cO3bg="
+    },
+    "@webassemblyjs/helper-module-context": {
+      "version": "1.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz",
+      "integrity": "sha1-JdiIS3aDmHGgimxvgGw5ee9xLwc=",
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0"
+      }
+    },
+    "@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
+      "integrity": "sha1-T+2L6sm4wU+MWLcNEk1UndH+V5A="
+    },
+    "@webassemblyjs/helper-wasm-section": {
+      "version": "1.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
+      "integrity": "sha1-WkE41aYpK6GLBMWuSXF+QWeWU0Y=",
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0"
+      }
+    },
+    "@webassemblyjs/ieee754": {
+      "version": "1.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
+      "integrity": "sha1-Fceg+6roP7JhQ7us9tbfFwKtOeQ=",
+      "requires": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "@webassemblyjs/leb128": {
+      "version": "1.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
+      "integrity": "sha1-8Zygt2ptxVYjoJz/p2noOPoeHJU=",
+      "requires": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webassemblyjs/utf8": {
+      "version": "1.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
+      "integrity": "sha1-BNM7Y2945qaBMifoJAL3Y3tiKas="
+    },
+    "@webassemblyjs/wasm-edit": {
+      "version": "1.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
+      "integrity": "sha1-P+bXnT8PkiGDqoYALELdJWz+6c8=",
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/helper-wasm-section": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0",
+        "@webassemblyjs/wasm-opt": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0",
+        "@webassemblyjs/wast-printer": "1.9.0"
+      }
+    },
+    "@webassemblyjs/wasm-gen": {
+      "version": "1.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
+      "integrity": "sha1-ULxw7Gje2OJ2OwGhQYv0NJGnpJw=",
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/ieee754": "1.9.0",
+        "@webassemblyjs/leb128": "1.9.0",
+        "@webassemblyjs/utf8": "1.9.0"
+      }
+    },
+    "@webassemblyjs/wasm-opt": {
+      "version": "1.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
+      "integrity": "sha1-IhEYHlsxMmRDzIES658LkChyGmE=",
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0"
+      }
+    },
+    "@webassemblyjs/wasm-parser": {
+      "version": "1.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
+      "integrity": "sha1-nUjkSCbfSmWYKUqmyHRp1kL/9l4=",
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-api-error": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/ieee754": "1.9.0",
+        "@webassemblyjs/leb128": "1.9.0",
+        "@webassemblyjs/utf8": "1.9.0"
+      }
+    },
+    "@webassemblyjs/wast-parser": {
+      "version": "1.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz",
+      "integrity": "sha1-MDERXXmsW9JhVWzsw/qQo+9FGRQ=",
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/floating-point-hex-parser": "1.9.0",
+        "@webassemblyjs/helper-api-error": "1.9.0",
+        "@webassemblyjs/helper-code-frame": "1.9.0",
+        "@webassemblyjs/helper-fsm": "1.9.0",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webassemblyjs/wast-printer": {
+      "version": "1.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
+      "integrity": "sha1-STXVTIX+9jewDOn1I3dFHQDUeJk=",
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/wast-parser": "1.9.0",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A="
+    },
+    "@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha1-0pHGpOl5ibXGHZrPOWrk/hM6cY0="
+    },
+    "abab": {
+      "version": "2.0.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha1-wLZ4+zLWD8EhnHhNaoJv44Wut5o="
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg="
+    },
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha1-UxvHJlF6OytB+FACHGzBXqq1B80=",
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
+    "acorn": {
+      "version": "8.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/acorn/-/acorn-8.5.0.tgz",
+      "integrity": "sha1-RRLMuZs2mMdSWR6btEcuOK1DzuI="
+    },
+    "acorn-globals": {
+      "version": "6.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/acorn-globals/-/acorn-globals-6.0.0.tgz",
+      "integrity": "sha1-Rs3Tnw+P8IqHZhm1X1rIptx3C0U=",
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo="
+        }
+      }
+    },
+    "acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha1-DeiJpgEgOQmw++B7iTjcIdLpZ7w="
+    },
+    "address": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/address/-/address-1.1.2.tgz",
+      "integrity": "sha1-vxEWycdYxRt6kz0pa3LCIe2UKLY="
+    },
+    "adjust-sourcemap-loader": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/adjust-sourcemap-loader/-/adjust-sourcemap-loader-3.0.0.tgz",
+      "integrity": "sha1-WuEvtbexxYXoC7taY+wWOhpF5h4=",
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "regex-parser": "^2.2.11"
+      }
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+      "requires": {
+        "debug": "4"
+      }
+    },
+    "aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo=",
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE="
+        }
+      }
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-errors": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ajv-errors/-/ajv-errors-1.0.1.tgz",
+      "integrity": "sha1-81mGrOuRr63sQQL72FAUlQzvpk0="
+    },
+    "ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha1-MfKdpatuANHC0yms97WSlhTVAU0="
+    },
+    "alphanum-sort": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+      "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
+    "ansi-colors": {
+      "version": "3.2.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-colors/-/ansi-colors-3.2.4.tgz",
+      "integrity": "sha1-46PaS/uubIapwoViXeEkojQCb78="
+    },
+    "ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha1-ayKR0dt9mLZSHV8e+kLQ86n+tl4=",
+      "requires": {
+        "type-fest": "^0.21.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha1-0mCiSwGYQ24TP6JqUkptZfo7Ljc="
+        }
+      }
+    },
+    "ansi-html": {
+      "version": "0.0.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-html/-/ansi-html-0.0.7.tgz",
+      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha1-wFV8CWrzLxBhmPT04qODU343hxY=",
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+      "integrity": "sha1-sVR0qTKtq0/4pQ2a36fk6SbyEUY=",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "arity-n": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/arity-n/-/arity-n-1.0.4.tgz",
+      "integrity": "sha1-2edrEXM+CFacCEeuezmyhgswt0U="
+    },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+    },
+    "array-flatten": {
+      "version": "2.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/array-flatten/-/array-flatten-2.1.2.tgz",
+      "integrity": "sha1-JO+AoowaiTYX4hSbDG0NeIKTsJk="
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha1-t5hCCtvrHego2ErNii4j0+/oXo0="
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha1-EamAuE67kXgc41sP3C7ilON4Pwc=",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og="
+        }
+      }
+    },
+    "assert": {
+      "version": "1.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "util": "0.10.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+        },
+        "util": {
+          "version": "0.10.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/util/-/util-0.10.3.tgz",
+          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+          "requires": {
+            "inherits": "2.0.1"
+          }
+        }
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+    },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/async/-/async-2.6.3.tgz",
+      "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "async-each": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha1-tyfb+H12UWAvBvTUrDh/R9kbDL8="
+    },
+    "async-foreach": {
+      "version": "0.1.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/async-foreach/-/async-foreach-0.1.3.tgz",
+      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
+    },
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha1-3TeelPDbgxCwgpH51kwyCXZmF/0="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha1-YCzUtG6EStTv/JKoARo8RuAjjcI="
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k="
+    },
+    "autoprefixer": {
+      "version": "9.8.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/autoprefixer/-/autoprefixer-9.8.8.tgz",
+      "integrity": "sha1-/UvUWVOF+m8GWZ3nSaTV96R0lXo=",
+      "requires": {
+        "browserslist": "^4.12.0",
+        "caniuse-lite": "^1.0.30001109",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "picocolors": "^0.2.1",
+        "postcss": "^7.0.32",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "dependencies": {
+        "picocolors": {
+          "version": "0.2.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/picocolors/-/picocolors-0.2.1.tgz",
+          "integrity": "sha1-VwZw95NkaFHRuhNZlpYqutWHhZ8="
+        }
+      }
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.11.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha1-1h9G2DslGSUOJ4Ta9bCUeai0HFk="
+    },
+    "babel-eslint": {
+      "version": "10.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "integrity": "sha1-aWjlaKkQt4+zd5zdi2rC9HmUMjI=",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4="
+        }
+      }
+    },
+    "babel-extract-comments": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz",
+      "integrity": "sha1-Cirt+BQX7TkbheGLRhTmk6A1GiE=",
+      "requires": {
+        "babylon": "^6.18.0"
+      }
+    },
+    "babel-jest": {
+      "version": "26.6.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-jest/-/babel-jest-26.6.3.tgz",
+      "integrity": "sha1-2H0lywA3V3oMifguV1XF0pPAEFY=",
+      "requires": {
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/babel__core": "^7.1.7",
+        "babel-plugin-istanbul": "^6.0.0",
+        "babel-preset-jest": "^26.6.2",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "babel-loader": {
+      "version": "8.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-loader/-/babel-loader-8.1.0.tgz",
+      "integrity": "sha1-xhHVESvVIJq+i5+oTD5NolJ18cM=",
+      "requires": {
+        "find-cache-dir": "^2.1.0",
+        "loader-utils": "^1.4.0",
+        "mkdirp": "^0.5.3",
+        "pify": "^4.0.1",
+        "schema-utils": "^2.6.5"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        }
+      }
+    },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha1-hP2hnJduxcbe/vV/lCez3vZuF6M=",
+      "requires": {
+        "object.assign": "^4.1.0"
+      }
+    },
+    "babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha1-+ojsWSMv2bTjbbvFQKjsmptH2nM=",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      }
+    },
+    "babel-plugin-jest-hoist": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.6.2.tgz",
+      "integrity": "sha1-gYW9AwNI0lTG192XQ1Xmoosh5i0=",
+      "requires": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.0.0",
+        "@types/babel__traverse": "^7.0.6"
+      }
+    },
+    "babel-plugin-macros": {
+      "version": "2.8.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+      "integrity": "sha1-D5WKfMZVax5lNERl2ZERoeXhATg=",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "cosmiconfig": "^6.0.0",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha1-2k/uhTxS9rHmk19BwaL8UL1KmYI=",
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        }
+      }
+    },
+    "babel-plugin-named-asset-import": {
+      "version": "0.3.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.7.tgz",
+      "integrity": "sha1-FWzVXT8SKKV2V3Q0CTevyDmAZ90="
+    },
+    "babel-plugin-polyfill-corejs2": {
+      "version": "0.2.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.2.tgz",
+      "integrity": "sha1-6RJHheb9lPlLYYp5VOVpMFO/Uyc=",
+      "requires": {
+        "@babel/compat-data": "^7.13.11",
+        "@babel/helper-define-polyfill-provider": "^0.2.2",
+        "semver": "^6.1.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
+        }
+      }
+    },
+    "babel-plugin-polyfill-corejs3": {
+      "version": "0.2.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.5.tgz",
+      "integrity": "sha1-J3mEahahZSJEriaLHpBq2hB/r5I=",
+      "requires": {
+        "@babel/helper-define-polyfill-provider": "^0.2.2",
+        "core-js-compat": "^3.16.2"
+      }
+    },
+    "babel-plugin-polyfill-regenerator": {
+      "version": "0.2.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.2.tgz",
+      "integrity": "sha1-sxDI1kKsraNIwfo7Pmzg6FG+4Hc=",
+      "requires": {
+        "@babel/helper-define-polyfill-provider": "^0.2.2"
+      }
+    },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
+      }
+    },
+    "babel-plugin-transform-react-remove-prop-types": {
+      "version": "0.4.24",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
+      "integrity": "sha1-8u2vm0xqX75cHWeL+1MQeMFVXzo="
+    },
+    "babel-preset-current-node-syntax": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+      "integrity": "sha1-tDmSObibKgEfndvj5PQB/EDP9zs=",
+      "requires": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.8.3",
+        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-top-level-await": "^7.8.3"
+      }
+    },
+    "babel-preset-jest": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-preset-jest/-/babel-preset-jest-26.6.2.tgz",
+      "integrity": "sha1-dHhysRcd8DIlJCZYaIHWLTF5j+4=",
+      "requires": {
+        "babel-plugin-jest-hoist": "^26.6.2",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      }
+    },
+    "babel-preset-react-app": {
+      "version": "10.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-preset-react-app/-/babel-preset-react-app-10.0.0.tgz",
+      "integrity": "sha1-aJtg7ccF+KcM6H9Hqw5WCjF9cEU=",
+      "requires": {
+        "@babel/core": "7.12.3",
+        "@babel/plugin-proposal-class-properties": "7.12.1",
+        "@babel/plugin-proposal-decorators": "7.12.1",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "7.12.1",
+        "@babel/plugin-proposal-numeric-separator": "7.12.1",
+        "@babel/plugin-proposal-optional-chaining": "7.12.1",
+        "@babel/plugin-transform-flow-strip-types": "7.12.1",
+        "@babel/plugin-transform-react-display-name": "7.12.1",
+        "@babel/plugin-transform-runtime": "7.12.1",
+        "@babel/preset-env": "7.12.1",
+        "@babel/preset-react": "7.12.1",
+        "@babel/preset-typescript": "7.12.1",
+        "@babel/runtime": "7.12.1",
+        "babel-plugin-macros": "2.8.0",
+        "babel-plugin-transform-react-remove-prop-types": "0.4.24"
+      },
+      "dependencies": {
+        "@babel/plugin-proposal-class-properties": {
+          "version": "7.12.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz",
+          "integrity": "sha1-oIL/VB8qKaSCEGW4rdk0bAwW5d4=",
+          "requires": {
+            "@babel/helper-create-class-features-plugin": "^7.12.1",
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-proposal-nullish-coalescing-operator": {
+          "version": "7.12.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.1.tgz",
+          "integrity": "sha1-PtT/8xwBXn8/FGfxkNvlRc17BGw=",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+          }
+        },
+        "@babel/plugin-proposal-numeric-separator": {
+          "version": "7.12.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.1.tgz",
+          "integrity": "sha1-DixndMTOSL5BIRm01pOsd392haY=",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+          }
+        },
+        "@babel/plugin-proposal-optional-chaining": {
+          "version": "7.12.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.1.tgz",
+          "integrity": "sha1-zOEiID/IoyeUKW/Dd8be2vQ2N5c=",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
+            "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+          }
+        },
+        "@babel/plugin-transform-react-display-name": {
+          "version": "7.12.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.12.1.tgz",
+          "integrity": "sha1-HLzQw7HWZIxVN0oi/JtrflNBwA0=",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/preset-env": {
+          "version": "7.12.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/preset-env/-/preset-env-7.12.1.tgz",
+          "integrity": "sha1-nH5cqCoZ78hlOEu0mJFI0u5desI=",
+          "requires": {
+            "@babel/compat-data": "^7.12.1",
+            "@babel/helper-compilation-targets": "^7.12.1",
+            "@babel/helper-module-imports": "^7.12.1",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-validator-option": "^7.12.1",
+            "@babel/plugin-proposal-async-generator-functions": "^7.12.1",
+            "@babel/plugin-proposal-class-properties": "^7.12.1",
+            "@babel/plugin-proposal-dynamic-import": "^7.12.1",
+            "@babel/plugin-proposal-export-namespace-from": "^7.12.1",
+            "@babel/plugin-proposal-json-strings": "^7.12.1",
+            "@babel/plugin-proposal-logical-assignment-operators": "^7.12.1",
+            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
+            "@babel/plugin-proposal-numeric-separator": "^7.12.1",
+            "@babel/plugin-proposal-object-rest-spread": "^7.12.1",
+            "@babel/plugin-proposal-optional-catch-binding": "^7.12.1",
+            "@babel/plugin-proposal-optional-chaining": "^7.12.1",
+            "@babel/plugin-proposal-private-methods": "^7.12.1",
+            "@babel/plugin-proposal-unicode-property-regex": "^7.12.1",
+            "@babel/plugin-syntax-async-generators": "^7.8.0",
+            "@babel/plugin-syntax-class-properties": "^7.12.1",
+            "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+            "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+            "@babel/plugin-syntax-json-strings": "^7.8.0",
+            "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+            "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+            "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+            "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+            "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+            "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+            "@babel/plugin-syntax-top-level-await": "^7.12.1",
+            "@babel/plugin-transform-arrow-functions": "^7.12.1",
+            "@babel/plugin-transform-async-to-generator": "^7.12.1",
+            "@babel/plugin-transform-block-scoped-functions": "^7.12.1",
+            "@babel/plugin-transform-block-scoping": "^7.12.1",
+            "@babel/plugin-transform-classes": "^7.12.1",
+            "@babel/plugin-transform-computed-properties": "^7.12.1",
+            "@babel/plugin-transform-destructuring": "^7.12.1",
+            "@babel/plugin-transform-dotall-regex": "^7.12.1",
+            "@babel/plugin-transform-duplicate-keys": "^7.12.1",
+            "@babel/plugin-transform-exponentiation-operator": "^7.12.1",
+            "@babel/plugin-transform-for-of": "^7.12.1",
+            "@babel/plugin-transform-function-name": "^7.12.1",
+            "@babel/plugin-transform-literals": "^7.12.1",
+            "@babel/plugin-transform-member-expression-literals": "^7.12.1",
+            "@babel/plugin-transform-modules-amd": "^7.12.1",
+            "@babel/plugin-transform-modules-commonjs": "^7.12.1",
+            "@babel/plugin-transform-modules-systemjs": "^7.12.1",
+            "@babel/plugin-transform-modules-umd": "^7.12.1",
+            "@babel/plugin-transform-named-capturing-groups-regex": "^7.12.1",
+            "@babel/plugin-transform-new-target": "^7.12.1",
+            "@babel/plugin-transform-object-super": "^7.12.1",
+            "@babel/plugin-transform-parameters": "^7.12.1",
+            "@babel/plugin-transform-property-literals": "^7.12.1",
+            "@babel/plugin-transform-regenerator": "^7.12.1",
+            "@babel/plugin-transform-reserved-words": "^7.12.1",
+            "@babel/plugin-transform-shorthand-properties": "^7.12.1",
+            "@babel/plugin-transform-spread": "^7.12.1",
+            "@babel/plugin-transform-sticky-regex": "^7.12.1",
+            "@babel/plugin-transform-template-literals": "^7.12.1",
+            "@babel/plugin-transform-typeof-symbol": "^7.12.1",
+            "@babel/plugin-transform-unicode-escapes": "^7.12.1",
+            "@babel/plugin-transform-unicode-regex": "^7.12.1",
+            "@babel/preset-modules": "^0.1.3",
+            "@babel/types": "^7.12.1",
+            "core-js-compat": "^3.6.2",
+            "semver": "^5.5.0"
+          }
+        },
+        "@babel/preset-react": {
+          "version": "7.12.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/preset-react/-/preset-react-7.12.1.tgz",
+          "integrity": "sha1-fwIrE/VbbdgvAPFtHFma5imFNYw=",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/plugin-transform-react-display-name": "^7.12.1",
+            "@babel/plugin-transform-react-jsx": "^7.12.1",
+            "@babel/plugin-transform-react-jsx-development": "^7.12.1",
+            "@babel/plugin-transform-react-jsx-self": "^7.12.1",
+            "@babel/plugin-transform-react-jsx-source": "^7.12.1",
+            "@babel/plugin-transform-react-pure-annotations": "^7.12.1"
+          }
+        },
+        "@babel/runtime": {
+          "version": "7.12.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/runtime/-/runtime-7.12.1.tgz",
+          "integrity": "sha1-tBFqa2cR0BCy2tO3tuQ78bmVR0A=",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
+        }
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha1-2TM9+nsGXjR8xWgiGdb2kIWcwuw="
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk="
+        }
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM="
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/base/-/base-0.11.2.tgz",
+      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo="
+    },
+    "batch": {
+      "version": "0.6.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/batch/-/batch-0.6.1.tgz",
+      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "bfj": {
+      "version": "7.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bfj/-/bfj-7.0.2.tgz",
+      "integrity": "sha1-GYjOdvOt2awpE/2LpHqtnmUb+7I=",
+      "requires": {
+        "bluebird": "^3.5.5",
+        "check-types": "^11.1.1",
+        "hoopy": "^0.1.4",
+        "tryer": "^1.0.1"
+      }
+    },
+    "big.js": {
+      "version": "5.2.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha1-ZfCvOC9Xi83HQr2cKB6cstd2gyg="
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha1-dfUC7q+f/eQvyYgpZFvk6na9ni0=",
+      "optional": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "requires": {
+        "inherits": "~2.0.0"
+      }
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28="
+    },
+    "bn.js": {
+      "version": "5.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bn.js/-/bn.js-5.2.0.tgz",
+      "integrity": "sha1-NYhgZ0OWxpl3canQUfzBtX1K4AI="
+    },
+    "body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha1-lrJwnlfJxOCab9Zqj9l5hE9p8Io=",
+      "requires": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bytes/-/bytes-3.1.0.tgz",
+          "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw="
+        }
+      }
+    },
+    "bonjour": {
+      "version": "3.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bonjour/-/bonjour-3.5.0.tgz",
+      "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+      "requires": {
+        "array-flatten": "^2.1.0",
+        "deep-equal": "^1.0.1",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.2",
+        "multicast-dns": "^6.0.1",
+        "multicast-dns-service-types": "^1.1.0"
+      }
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
+    "bpk-mixins": {
+      "version": "21.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bpk-mixins/-/bpk-mixins-21.0.4.tgz",
+      "integrity": "sha1-ND7+H/KWxaeRyLrcLOcoN3RmpuA=",
+      "requires": {
+        "@skyscanner/bpk-foundations-web": "^1.0.0",
+        "@skyscanner/bpk-svgs": "^12.7.2"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha1-PJtLfXgsgSHlbxAQbYTA0P/JRiY="
+    },
+    "browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
+      "requires": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
+      "requires": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "browserify-rsa": {
+      "version": "4.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+      "integrity": "sha1-sv0Gtbda4pf3zi3GUfkY9b4VjI0=",
+      "requires": {
+        "bn.js": "^5.0.0",
+        "randombytes": "^2.0.1"
+      }
+    },
+    "browserify-sign": {
+      "version": "4.2.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/browserify-sign/-/browserify-sign-4.2.1.tgz",
+      "integrity": "sha1-6vSt1G3VS+O7OzbAzxWrvrp5VsM=",
+      "requires": {
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.3",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY="
+        }
+      }
+    },
+    "browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
+      "requires": {
+        "pako": "~1.0.5"
+      }
+    },
+    "browserslist": {
+      "version": "4.17.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/browserslist/-/browserslist-4.17.4.tgz",
+      "integrity": "sha1-cuJQivKkA67ApJhH7zG9gjxX6tQ=",
+      "requires": {
+        "caniuse-lite": "^1.0.30001265",
+        "electron-to-chromium": "^1.3.867",
+        "escalade": "^3.1.1",
+        "node-releases": "^2.0.0",
+        "picocolors": "^1.0.0"
+      }
+    },
+    "bser": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha1-5nh9og7OnQeZhTPP2d5vXDj0vAU=",
+      "requires": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha1-Iw6tNEACmIZEhBqwJEr4xEu+Pvg=",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U="
+    },
+    "buffer-indexof": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+      "integrity": "sha1-Uvq8xqYG0aADAoAmSO9o9jnaJow="
+    },
+    "buffer-json": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/buffer-json/-/buffer-json-2.0.0.tgz",
+      "integrity": "sha1-9z4TseQvGW/i/WfQAcfXEH7dfCM="
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+    },
+    "builtin-modules": {
+      "version": "3.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/builtin-modules/-/builtin-modules-3.2.0.tgz",
+      "integrity": "sha1-RdXbmefuXmvE82LgCL+RerUEmIc="
+    },
+    "builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+    },
+    "cacache": {
+      "version": "15.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cacache/-/cacache-15.3.0.tgz",
+      "integrity": "sha1-3IU4D7L1Vv492kxxm/oOyHWn8es=",
+      "requires": {
+        "@npmcli/fs": "^1.0.0",
+        "@npmcli/move-file": "^1.0.1",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.1",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34="
+        },
+        "tar": {
+          "version": "6.1.11",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tar/-/tar-6.1.11.tgz",
+          "integrity": "sha1-Z2CjjwA6+hsv/Q/+npq70Oqz1iE=",
+          "requires": {
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.1",
+            "mkdirp": "^1.0.3",
+            "yallist": "^4.0.0"
+          }
+        }
+      }
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
+    },
+    "cache-loader": {
+      "version": "4.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cache-loader/-/cache-loader-4.1.0.tgz",
+      "integrity": "sha1-mUjK41OuwKH8ser9ojAIFuyFOH4=",
+      "requires": {
+        "buffer-json": "^2.0.0",
+        "find-cache-dir": "^3.0.0",
+        "loader-utils": "^1.2.3",
+        "mkdirp": "^0.5.1",
+        "neo-async": "^2.6.1",
+        "schema-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "find-cache-dir": {
+          "version": "3.3.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+          "integrity": "sha1-swxbbv8HMHMa6pu9nb7L2AJW1ks=",
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^3.0.2",
+            "pkg-dir": "^4.1.0"
+          }
+        },
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha1-QV6WcEazp/HRhSd9hKpYIDcmoT8=",
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
+        }
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "caller-callsite": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+      "requires": {
+        "callsites": "^2.0.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/callsites/-/callsites-2.0.0.tgz",
+          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+        }
+      }
+    },
+    "caller-path": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/caller-path/-/caller-path-2.0.0.tgz",
+      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+      "requires": {
+        "caller-callsite": "^2.0.0"
+      }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M="
+    },
+    "camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha1-lygHKpVPgFIoIlpt7qazhGHhvVo=",
+      "requires": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha1-6KM1rdXOrlGqJh0ypJAVjvBC7wE="
+        }
+      }
+    },
+    "camelcase": {
+      "version": "6.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/camelcase/-/camelcase-6.2.0.tgz",
+      "integrity": "sha1-kkr4gcnVJaydh/QNlk5c6pgqGAk="
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "requires": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        }
+      }
+    },
+    "caniuse-api": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/caniuse-api/-/caniuse-api-3.0.0.tgz",
+      "integrity": "sha1-Xk2Q4idJYdRikZl99Znj7QCO5MA=",
+      "requires": {
+        "browserslist": "^4.0.0",
+        "caniuse-lite": "^1.0.0",
+        "lodash.memoize": "^4.1.2",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001270",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/caniuse-lite/-/caniuse-lite-1.0.30001270.tgz",
+      "integrity": "sha1-zJw3pOxcGo1hb8e6zpArsFOwzeo="
+    },
+    "capture-exit": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/capture-exit/-/capture-exit-2.0.0.tgz",
+      "integrity": "sha1-+5U7+uvreB9iiYI52rtCbQilCaQ=",
+      "requires": {
+        "rsvp": "^4.8.4"
+      }
+    },
+    "case-sensitive-paths-webpack-plugin": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.3.0.tgz",
+      "integrity": "sha1-I6xhPMmoVuT4j/i7c7u16YmCXPc="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha1-10Q1giYhf5ge1Y9Hmx1rzClUXc8="
+    },
+    "check-types": {
+      "version": "11.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/check-types/-/check-types-11.1.2.tgz",
+      "integrity": "sha1-hqfBK/VTn2Mk6w5wyoiWwOOPPi8="
+    },
+    "chokidar": {
+      "version": "3.5.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha1-26OXb8rbAW9m/TZQIdkWANAcHnU=",
+      "optional": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
+    },
+    "chownr": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha1-Fb++U9LqtM9w8YqM1o6+Wzyx3s4="
+    },
+    "chrome-trace-event": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+      "integrity": "sha1-EBXs7UdB4V0GZkqVfbv1DQQeJqw="
+    },
+    "ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha1-Z6npZL4xpR4V5QENWObxKDQAL0Y="
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "cjs-module-lexer": {
+      "version": "0.6.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz",
+      "integrity": "sha1-QYb8yg6uF1lwruhwuf4tbPjVZV8="
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "clean-css": {
+      "version": "4.2.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/clean-css/-/clean-css-4.2.3.tgz",
+      "integrity": "sha1-UHtd59l7SO5T2ErbAWD/YhY4D3g=",
+      "requires": {
+        "source-map": "~0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        }
+      }
+    },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs="
+    },
+    "cliui": {
+      "version": "6.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha1-UR1wLAxOQcoVbX0OlgIfI+EyJbE=",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ="
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
+    "clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha1-wZ/Zvbv4WUK0/ZechNz31fB8I4c=",
+      "requires": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "coa": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/coa/-/coa-2.0.2.tgz",
+      "integrity": "sha1-Q/bCEVG07yv1cYfbDXPeIp4+fsM=",
+      "requires": {
+        "@types/q": "^1.5.1",
+        "chalk": "^2.4.1",
+        "q": "^1.1.2"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "collect-v8-coverage": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
+      "integrity": "sha1-zCyOlPwYu9/+ZNZTRXDIpnOyf1k="
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
+    "color": {
+      "version": "3.2.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color/-/color-3.2.1.tgz",
+      "integrity": "sha1-NUTcGYyvRJDD7MmnkLVP6f9F4WQ=",
+      "requires": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.6.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-string/-/color-string-1.6.0.tgz",
+      "integrity": "sha1-w5FfYf4mdnLLfh4GTJ1pIhn2wxI=",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "4.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha1-n9YCvZNilOnp70aj9NaWQESxgGg="
+    },
+    "common-tags": {
+      "version": "1.8.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha1-jjFT5ULUo56bEFVENK+q+YlWqTc="
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A="
+    },
+    "compose-function": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/compose-function/-/compose-function-3.0.3.tgz",
+      "integrity": "sha1-ntZ18TzFRQHTCVCkhv9qe6OrGF8=",
+      "requires": {
+        "arity-n": "^1.0.4"
+      }
+    },
+    "compressible": {
+      "version": "2.0.18",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha1-r1PMprBw1MPAdQ+9dyhqbXzEb7o=",
+      "requires": {
+        "mime-db": ">= 1.43.0 < 2"
+      }
+    },
+    "compression": {
+      "version": "1.7.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/compression/-/compression-1.7.4.tgz",
+      "integrity": "sha1-lVI+/xcMpXwpoMpB5v4TH0Hlu48=",
+      "requires": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "connect-history-api-fallback": {
+      "version": "1.6.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+      "integrity": "sha1-izIIk1kwjRERFdgcrT/Oq4iPl7w="
+    },
+    "console-browserify": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha1-ZwY871fOts9Jk6KrOlWECujEkzY="
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
+    "constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
+    },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha1-4TDK9+cnkIfFYWwgB9BIVpiYT70=",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
+    },
+    "convert-source-map": {
+      "version": "1.8.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha1-8zc8MtIbTXgN2ABFFGhPt5HKQ2k=",
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "cookie": {
+      "version": "0.4.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha1-vrQ35wIrO21JAZ0IhmUwPr6cFLo="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "copy-concurrently": {
+      "version": "1.0.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+      "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
+      "requires": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+    },
+    "core-js": {
+      "version": "3.18.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/core-js/-/core-js-3.18.3.tgz",
+      "integrity": "sha1-hqC7otjsPfhg/vzAeo0Rl3nwFQk="
+    },
+    "core-js-compat": {
+      "version": "3.18.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/core-js-compat/-/core-js-compat-3.18.3.tgz",
+      "integrity": "sha1-4OfoerxV77VH5/oZFp5F+p3yemc=",
+      "requires": {
+        "browserslist": "^4.17.3",
+        "semver": "7.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-7.0.0.tgz",
+          "integrity": "sha1-XzyjV2HkfgWyBsba/yz4FPAxa44="
+        }
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U="
+    },
+    "cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha1-cU11ZSLKzoZ4Z8y0R0xdAbuuXW0=",
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      }
+    },
+    "create-ecdh": {
+      "version": "4.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha1-1uf0v/pmc2CFoHYv06YyaE2rzE4=",
+      "requires": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og="
+        }
+      }
+    },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
+      "requires": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
+        }
+      }
+    },
+    "crypto-browserify": {
+      "version": "3.12.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
+      "requires": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
+      }
+    },
+    "crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+    },
+    "css": {
+      "version": "2.2.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/css/-/css-2.2.4.tgz",
+      "integrity": "sha1-xkZ1XHOXHyu6amAeLPL9cbEpiSk=",
+      "requires": {
+        "inherits": "^2.0.3",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.5.2",
+        "urix": "^0.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        }
+      }
+    },
+    "css-blank-pseudo": {
+      "version": "0.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz",
+      "integrity": "sha1-3979MlS/ioICeZNnTM81SDv8s8U=",
+      "requires": {
+        "postcss": "^7.0.5"
+      }
+    },
+    "css-color-names": {
+      "version": "0.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/css-color-names/-/css-color-names-0.0.4.tgz",
+      "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
+    },
+    "css-declaration-sorter": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
+      "integrity": "sha1-wZiUD2OnbX42wecQGLABchBUyyI=",
+      "requires": {
+        "postcss": "^7.0.1",
+        "timsort": "^0.3.0"
+      }
+    },
+    "css-has-pseudo": {
+      "version": "0.10.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/css-has-pseudo/-/css-has-pseudo-0.10.0.tgz",
+      "integrity": "sha1-PGQqs0yiQsWcQaEl35EFhB9pZu4=",
+      "requires": {
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^5.0.0-rc.4"
+      },
+      "dependencies": {
+        "cssesc": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha1-OxO9G7HLNuG8taTc0n9UxdyzVwM="
+        },
+        "postcss-selector-parser": {
+          "version": "5.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "integrity": "sha1-JJBENWaXsztk8aj3yAki3d7nGVw=",
+          "requires": {
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
+      }
+    },
+    "css-loader": {
+      "version": "4.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/css-loader/-/css-loader-4.3.0.tgz",
+      "integrity": "sha1-yIivZLKlsuhUYscsD0qFx+Lggh4=",
+      "requires": {
+        "camelcase": "^6.0.0",
+        "cssesc": "^3.0.0",
+        "icss-utils": "^4.1.1",
+        "loader-utils": "^2.0.0",
+        "postcss": "^7.0.32",
+        "postcss-modules-extract-imports": "^2.0.0",
+        "postcss-modules-local-by-default": "^3.0.3",
+        "postcss-modules-scope": "^2.2.0",
+        "postcss-modules-values": "^3.0.0",
+        "postcss-value-parser": "^4.1.0",
+        "schema-utils": "^2.7.1",
+        "semver": "^7.3.2"
+      }
+    },
+    "css-prefers-color-scheme": {
+      "version": "3.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/css-prefers-color-scheme/-/css-prefers-color-scheme-3.1.1.tgz",
+      "integrity": "sha1-b4MKJxQZnU8NDQu4onkW7WXP8fQ=",
+      "requires": {
+        "postcss": "^7.0.5"
+      }
+    },
+    "css-select": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/css-select/-/css-select-2.1.0.tgz",
+      "integrity": "sha1-ajRlM1ZjWTSoG6ymjQJVQyEF2+8=",
+      "requires": {
+        "boolbase": "^1.0.0",
+        "css-what": "^3.2.1",
+        "domutils": "^1.7.0",
+        "nth-check": "^1.0.2"
+      }
+    },
+    "css-select-base-adapter": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
+      "integrity": "sha1-Oy/0lyzDYquIVhUHqVQIoUMhNdc="
+    },
+    "css-tree": {
+      "version": "1.0.0-alpha.37",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
+      "integrity": "sha1-mL69YsTB2flg7DQM+fdSLjBwmiI=",
+      "requires": {
+        "mdn-data": "2.0.4",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        }
+      }
+    },
+    "css-what": {
+      "version": "3.4.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/css-what/-/css-what-3.4.2.tgz",
+      "integrity": "sha1-6nAm/LAXd+295SEk4h8yfnrpUOQ="
+    },
+    "cssdb": {
+      "version": "4.4.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cssdb/-/cssdb-4.4.0.tgz",
+      "integrity": "sha1-O/LypowQ9cagir2SN4Mx7oA83bA="
+    },
+    "cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha1-N3QZGZA7hoVl4cCep0dEXNGJg+4="
+    },
+    "cssnano": {
+      "version": "4.1.11",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cssnano/-/cssnano-4.1.11.tgz",
+      "integrity": "sha1-x7X1uB2iacsf2YLLlgwSAJEMmpk=",
+      "requires": {
+        "cosmiconfig": "^5.0.0",
+        "cssnano-preset-default": "^4.0.8",
+        "is-resolvable": "^1.0.0",
+        "postcss": "^7.0.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "5.2.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+          "integrity": "sha1-BA9yaAnFked6F8CjYmykW08Wixo=",
+          "requires": {
+            "import-fresh": "^2.0.0",
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.13.1",
+            "parse-json": "^4.0.0"
+          }
+        },
+        "import-fresh": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/import-fresh/-/import-fresh-2.0.0.tgz",
+          "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+          "requires": {
+            "caller-path": "^2.0.0",
+            "resolve-from": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+        }
+      }
+    },
+    "cssnano-preset-default": {
+      "version": "4.0.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cssnano-preset-default/-/cssnano-preset-default-4.0.8.tgz",
+      "integrity": "sha1-kgYisfwelaNOiDggPxOXpQTy0/8=",
+      "requires": {
+        "css-declaration-sorter": "^4.0.1",
+        "cssnano-util-raw-cache": "^4.0.1",
+        "postcss": "^7.0.0",
+        "postcss-calc": "^7.0.1",
+        "postcss-colormin": "^4.0.3",
+        "postcss-convert-values": "^4.0.1",
+        "postcss-discard-comments": "^4.0.2",
+        "postcss-discard-duplicates": "^4.0.2",
+        "postcss-discard-empty": "^4.0.1",
+        "postcss-discard-overridden": "^4.0.1",
+        "postcss-merge-longhand": "^4.0.11",
+        "postcss-merge-rules": "^4.0.3",
+        "postcss-minify-font-values": "^4.0.2",
+        "postcss-minify-gradients": "^4.0.2",
+        "postcss-minify-params": "^4.0.2",
+        "postcss-minify-selectors": "^4.0.2",
+        "postcss-normalize-charset": "^4.0.1",
+        "postcss-normalize-display-values": "^4.0.2",
+        "postcss-normalize-positions": "^4.0.2",
+        "postcss-normalize-repeat-style": "^4.0.2",
+        "postcss-normalize-string": "^4.0.2",
+        "postcss-normalize-timing-functions": "^4.0.2",
+        "postcss-normalize-unicode": "^4.0.1",
+        "postcss-normalize-url": "^4.0.1",
+        "postcss-normalize-whitespace": "^4.0.2",
+        "postcss-ordered-values": "^4.1.2",
+        "postcss-reduce-initial": "^4.0.3",
+        "postcss-reduce-transforms": "^4.0.2",
+        "postcss-svgo": "^4.0.3",
+        "postcss-unique-selectors": "^4.0.1"
+      }
+    },
+    "cssnano-util-get-arguments": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz",
+      "integrity": "sha1-7ToIKZ8h11dBsg87gfGU7UnMFQ8="
+    },
+    "cssnano-util-get-match": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cssnano-util-get-match/-/cssnano-util-get-match-4.0.0.tgz",
+      "integrity": "sha1-wOTKB/U4a7F+xeUiULT1lhNlFW0="
+    },
+    "cssnano-util-raw-cache": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cssnano-util-raw-cache/-/cssnano-util-raw-cache-4.0.1.tgz",
+      "integrity": "sha1-sm1f1fcqEd/np4RvtMZyYPlr8oI=",
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "cssnano-util-same-parent": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.1.tgz",
+      "integrity": "sha1-V0CC+yhZ0ttDOFWDXZqEVuoYu/M="
+    },
+    "csso": {
+      "version": "4.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/csso/-/csso-4.2.0.tgz",
+      "integrity": "sha1-6jpWE0bo3J9UbW/r7dUBh884lSk=",
+      "requires": {
+        "css-tree": "^1.1.2"
+      },
+      "dependencies": {
+        "css-tree": {
+          "version": "1.1.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/css-tree/-/css-tree-1.1.3.tgz",
+          "integrity": "sha1-60hw+2/XcHMn7JXC/yqwm16NuR0=",
+          "requires": {
+            "mdn-data": "2.0.14",
+            "source-map": "^0.6.1"
+          }
+        },
+        "mdn-data": {
+          "version": "2.0.14",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/mdn-data/-/mdn-data-2.0.14.tgz",
+          "integrity": "sha1-cRP8QoGRfWPOKbQ0RvcB5owlulA="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        }
+      }
+    },
+    "cssom": {
+      "version": "0.4.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cssom/-/cssom-0.4.4.tgz",
+      "integrity": "sha1-WmbPk9LQtmHYC/akT7ZfXC5OChA="
+    },
+    "cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha1-/2ZaDdvcMYZLCWR/NBY0Q9kLCFI=",
+      "requires": {
+        "cssom": "~0.3.6"
+      },
+      "dependencies": {
+        "cssom": {
+          "version": "0.3.8",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cssom/-/cssom-0.3.8.tgz",
+          "integrity": "sha1-nxJ29bK0Y/IRTT8sdSUK+MGjb0o="
+        }
+      }
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
+    },
+    "cyclist": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cyclist/-/cyclist-1.0.1.tgz",
+      "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
+    },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/d/-/d-1.0.1.tgz",
+      "integrity": "sha1-hpgJU3LVjb7jRv/Qxwk/mfj561o=",
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "data-urls": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/data-urls/-/data-urls-2.0.0.tgz",
+      "integrity": "sha1-FWSFpyljqXD11YIar2Qr7yvy25s=",
+      "requires": {
+        "abab": "^2.0.3",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0"
+      }
+    },
+    "debug": {
+      "version": "4.3.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha1-8KScGKyHeeMdSgxgKd+3aHPHQos=",
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "decimal.js": {
+      "version": "10.3.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha1-2MOkRKnGd0umDKatcmHDqU/V54M="
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
+    },
+    "deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha1-tcmMlCzv+vfLBR4k4UNKJaLmB2o=",
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha1-pvLc5hL63S7x9Rm3NVHxfoUZmDE="
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha1-RNLqNnm49NT/ujPwPYZfwee/SVU="
+    },
+    "default-gateway": {
+      "version": "4.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/default-gateway/-/default-gateway-4.2.0.tgz",
+      "integrity": "sha1-FnEEx1AMIRX23WmwpTa7jtcgVSs=",
+      "requires": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "del": {
+      "version": "4.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/del/-/del-4.1.1.tgz",
+      "integrity": "sha1-no8RciLqRKMf86FWwEm5kFKp8LQ=",
+      "requires": {
+        "@types/glob": "^7.1.1",
+        "globby": "^6.1.0",
+        "is-path-cwd": "^2.0.0",
+        "is-path-in-cwd": "^2.0.0",
+        "p-map": "^2.0.0",
+        "pify": "^4.0.1",
+        "rimraf": "^2.6.3"
+      },
+      "dependencies": {
+        "array-union": {
+          "version": "1.0.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/array-union/-/array-union-1.0.2.tgz",
+          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+          "requires": {
+            "array-uniq": "^1.0.1"
+          }
+        },
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "requires": {
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+            }
+          }
+        },
+        "p-map": {
+          "version": "2.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/p-map/-/p-map-2.1.0.tgz",
+          "integrity": "sha1-MQko/u+cnsxltosXaTAYpmXOoXU="
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "des.js": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/des.js/-/des.js-1.0.1.tgz",
+      "integrity": "sha1-U4IULhvcU/hdhtU+X0qn3rkeCEM=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha1-V29d/GOuGhkv8ZLYrTr2MImRtlE="
+    },
+    "detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha1-yccHdaScPQO8LAbZpzvlUPl4+LE="
+    },
+    "detect-port-alt": {
+      "version": "1.1.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
+      "integrity": "sha1-JHB96r6TLUo89iEwICfCsmZWgnU=",
+      "requires": {
+        "address": "^1.0.1",
+        "debug": "^2.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "diff-sequences": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/diff-sequences/-/diff-sequences-26.6.2.tgz",
+      "integrity": "sha1-SLqZFX3hkjQS7tQdtrbUqpynwLE="
+    },
+    "diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
+      "requires": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og="
+        }
+      }
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha1-Vtv3PZkqSpO6FYT0U0Bj/S5BcX8=",
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
+    "dns-equal": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dns-equal/-/dns-equal-1.0.0.tgz",
+      "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0="
+    },
+    "dns-packet": {
+      "version": "1.3.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dns-packet/-/dns-packet-1.3.4.tgz",
+      "integrity": "sha1-40VQZYJKJQe6iGxVqJljuxB97G8=",
+      "requires": {
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "dns-txt": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dns-txt/-/dns-txt-2.0.2.tgz",
+      "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+      "requires": {
+        "buffer-indexof": "^1.0.0"
+      }
+    },
+    "dom-converter": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dom-converter/-/dom-converter-0.2.0.tgz",
+      "integrity": "sha1-ZyGp2u4uKTaClVtq/kFncWJ7t2g=",
+      "requires": {
+        "utila": "~0.4"
+      }
+    },
+    "dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha1-GvuB9TNxcXXUeGVd68XjMtn5u1E=",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha1-mgtsJ4LtahxzI9QiZxg9+b2LHVc="
+        }
+      }
+    },
+    "domain-browser": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto="
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8="
+    },
+    "domexception": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/domexception/-/domexception-2.0.1.tgz",
+      "integrity": "sha1-+0Su+6eT4VdLCvau0oAdBXUp8wQ=",
+      "requires": {
+        "webidl-conversions": "^5.0.0"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "5.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "integrity": "sha1-rlnIoAsSFUOirMZcBDT1ew/BGv8="
+        }
+      }
+    },
+    "domhandler": {
+      "version": "4.2.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/domhandler/-/domhandler-4.2.2.tgz",
+      "integrity": "sha1-6CXXIdGahrjCAaNSZOImxnjudV8=",
+      "requires": {
+        "domelementtype": "^2.2.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha1-mgtsJ4LtahxzI9QiZxg9+b2LHVc="
+        }
+      }
+    },
+    "domutils": {
+      "version": "1.7.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha1-Vuo0HoNOBuZ0ivehyyXaZ+qfjCo=",
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha1-mytnDQCkMWZ6inW6Kc0bmICc51E=",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha1-6KM1rdXOrlGqJh0ypJAVjvBC7wE="
+        }
+      }
+    },
+    "dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha1-kMzOcIzZzYLMTcjD3dmr3VWyDog=",
+      "requires": {
+        "is-obj": "^2.0.0"
+      }
+    },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha1-l+YZJZradQ7qPk6j4mvO6lQksWo="
+    },
+    "dotenv-expand": {
+      "version": "5.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha1-P7rwIL/XlIhAcuomsel5HUWmKfA="
+    },
+    "duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha1-Or5DrvODX4rgd9E23c4PJ2sEAOY="
+    },
+    "duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha1-Kk31MX9sz9kfhtb9JdjYoQO4gwk=",
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "ejs": {
+      "version": "2.7.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ejs/-/ejs-2.7.4.tgz",
+      "integrity": "sha1-SGYSh1c9zFPjZsehrlLDoSDuybo="
+    },
+    "electron-to-chromium": {
+      "version": "1.3.873",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/electron-to-chromium/-/electron-to-chromium-1.3.873.tgz",
+      "integrity": "sha1-wjjJGZ5JUZUv6BWmXBvqtdtIJrg="
+    },
+    "elliptic": {
+      "version": "6.5.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha1-2jfOvTHnmhNn6UG1ku0fvr1Yq7s=",
+      "requires": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og="
+        }
+      }
+    },
+    "emittery": {
+      "version": "0.7.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/emittery/-/emittery-0.7.2.tgz",
+      "integrity": "sha1-JVlZCOE68PVnSrQZOW4vs5TN+oI="
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc="
+    },
+    "emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha1-VXBmIEatKeLpFucariYKvf9Pang="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "encoding": {
+      "version": "0.1.13",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha1-VldK/deR9UqOmyeFwFgqLSYhD6k=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha1-pS+AvzjaGVLrXGgXkHGYcaGnJQE=",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "enhanced-resolve": {
+      "version": "4.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
+      "integrity": "sha1-Lzz9hNvjtIfxjy2y7x4GSlccpew=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.5.0",
+        "tapable": "^1.0.0"
+      },
+      "dependencies": {
+        "memory-fs": {
+          "version": "0.5.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/memory-fs/-/memory-fs-0.5.0.tgz",
+          "integrity": "sha1-MkwBKIuIZSlm0WHbd4OHIIRajjw=",
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
+          }
+        }
+      }
+    },
+    "entities": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha1-CY3JDruD2N/6CJ1VJWs1HTTE2lU="
+    },
+    "errno": {
+      "version": "0.1.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha1-i7Ppx9Rjvkl2/4iPdrSAnrwugR8=",
+      "requires": {
+        "prr": "~1.0.1"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "2.0.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha1-WpmnB716TFinl5AtSNgoA+3mqtg=",
+      "requires": {
+        "stackframe": "^1.1.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.19.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/es-abstract/-/es-abstract-1.19.1.tgz",
+      "integrity": "sha1-1IhXlodpFpWd547aoN9FZicRXsM=",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.2",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.4",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.1",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.1",
+        "object-inspect": "^1.11.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.53",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha1-k8WjrP2+8nUiCtcmRK0C7hg2jeE=",
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha1-utXTwbzawoJp9MszHkMceKxwXRg=",
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "escodegen": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/escodegen/-/escodegen-2.0.0.tgz",
+      "integrity": "sha1-XjKxKDPoqo+jXhvwvvqJOASEx90=",
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "optional": true
+        }
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA="
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0="
+    },
+    "estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha1-MbxdYSyWtwQQa0d+bdXYqhOMtwA="
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q="
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha1-Lem2j2Uo1WRO9cWVJqG0oHMGFp8="
+    },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/events/-/events-3.3.0.tgz",
+      "integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA="
+    },
+    "eventsource": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/eventsource/-/eventsource-1.1.0.tgz",
+      "integrity": "sha1-AOjKfJIQnpSw3fMtrGd9hBAoz68=",
+      "requires": {
+        "original": "^1.0.0"
+      }
+    },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
+      "requires": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "exec-sh": {
+      "version": "0.3.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/exec-sh/-/exec-sh-0.3.6.tgz",
+      "integrity": "sha1-/yZPnjJVGaYMteJzaSlDSDzKY7w="
+    },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "expect": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/expect/-/expect-26.6.2.tgz",
+      "integrity": "sha1-xrmWvya/P+GLZ7LQ9R/JgbqTRBc=",
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "ansi-styles": "^4.0.0",
+        "jest-get-type": "^26.3.0",
+        "jest-matcher-utils": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-regex-util": "^26.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        }
+      }
+    },
+    "express": {
+      "version": "4.17.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/express/-/express-4.17.1.tgz",
+      "integrity": "sha1-RJH8OGBc9R+GKdOcK10Cb5ikwTQ=",
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "array-flatten": {
+          "version": "1.1.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/array-flatten/-/array-flatten-1.1.1.tgz",
+          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw="
+        }
+      }
+    },
+    "ext": {
+      "version": "1.6.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ext/-/ext-1.6.0.tgz",
+      "integrity": "sha1-OHHVBkHodMwXLitT+RmELRnbTFI=",
+      "requires": {
+        "type": "^2.5.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.5.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/type/-/type-2.5.0.tgz",
+          "integrity": "sha1-Ci54wud5B7JSq+XymMGwHGPw2z0="
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU="
+    },
+    "fast-glob": {
+      "version": "3.2.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fast-glob/-/fast-glob-3.2.7.tgz",
+      "integrity": "sha1-/Wy3otfpqnp4RhEehaGW1rL3ZqE=",
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      }
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM="
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "fastq": {
+      "version": "1.13.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha1-YWdg+Ip1Jr38WWt8q4wYk4w2uYw=",
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha1-fw2Sdc/dhqHJY9yLZfzEUe3Lsdo=",
+      "requires": {
+        "websocket-driver": ">=0.5.1"
+      }
+    },
+    "fb-watchman": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fb-watchman/-/fb-watchman-2.0.1.tgz",
+      "integrity": "sha1-/IT7OdJwnPP/bXQ3BhV7tXCKioU=",
+      "requires": {
+        "bser": "2.1.1"
+      }
+    },
+    "fbjs": {
+      "version": "0.8.17",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fbjs/-/fbjs-0.8.17.tgz",
+      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "dev": true,
+      "requires": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        },
+        "promise": {
+          "version": "7.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/promise/-/promise-7.3.1.tgz",
+          "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+          "dev": true,
+          "requires": {
+            "asap": "~2.0.3"
+          }
+        }
+      }
+    },
+    "figgy-pudding": {
+      "version": "3.5.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+      "integrity": "sha1-tO7oFIq7Adzx0aw0Nn1Z4S+mHW4="
+    },
+    "file-loader": {
+      "version": "6.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/file-loader/-/file-loader-6.1.1.tgz",
+      "integrity": "sha1-pvKd+z9ZM6HDULLbqiCsW+BTm6o=",
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "3.1.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/schema-utils/-/schema-utils-3.1.1.tgz",
+          "integrity": "sha1-vHTEtraZXB2I92qLd76nIZ4MgoE=",
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
+      "optional": true
+    },
+    "filesize": {
+      "version": "6.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/filesize/-/filesize-6.1.0.tgz",
+      "integrity": "sha1-6Bvap4DiRR1xTXHA16TzI403rQA="
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha1-t+fQAP/RGTjQ/bBTUG9uur6fWH0=",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      }
+    },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "flatten": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/flatten/-/flatten-1.0.3.tgz",
+      "integrity": "sha1-wSg6yfJ7Noq8HjbR/3sEUBowNWs="
+    },
+    "flush-write-stream": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+      "integrity": "sha1-jdfYc6G6vCB9lOrQwuDkQnbr8ug=",
+      "requires": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.3.6"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.14.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/follow-redirects/-/follow-redirects-1.14.4.tgz",
+      "integrity": "sha1-g4/fSKi73XnlLuUfsclOPtmLk3k="
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "fork-ts-checker-webpack-plugin": {
+      "version": "4.1.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-4.1.6.tgz",
+      "integrity": "sha1-UFXHA/6883+gZAXUAMEiuQUWf8U=",
+      "requires": {
+        "@babel/code-frame": "^7.5.5",
+        "chalk": "^2.4.1",
+        "micromatch": "^3.1.10",
+        "minimatch": "^3.0.4",
+        "semver": "^5.6.0",
+        "tapable": "^1.0.0",
+        "worker-rpc": "^0.1.0"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
+    "form-data": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha1-69U3kbeDVqma+aMA1CgsTV65dV8=",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha1-ImmTZCiq1MFcfr6XeahL8LKoGBE="
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
+    },
+    "fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha1-WVRGDHZKjaIJS6NVS/g55rmnyG0=",
+      "requires": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha1-f1A2/b8SxjwWkZDL5BmchSJx+fs=",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "fs-write-stream-atomic": {
+      "version": "1.0.10",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
+      "optional": true
+    },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha1-Touo7i1Ivk99DeUFRVVI6uWTIEU=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        }
+      }
+    },
+    "gaze": {
+      "version": "1.1.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/gaze/-/gaze-1.1.3.tgz",
+      "integrity": "sha1-xEFzPhO5J6yMD/C0w7Az8ogSkko=",
+      "requires": {
+        "globule": "^1.0.0"
+      }
+    },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA="
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34="
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha1-FfWfN2+FXERpY5SPDSTNNje0q8Y=",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "3.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+      "integrity": "sha1-tf3nfyLL4185C04ImSLFC85u9mQ="
+    },
+    "get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha1-jeLYA8/0TfO8bEVuZmizbDkm4Ro="
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha1-f9uByQAQH71WTdXxowr1qtweWNY=",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha1-0VU1r3cy4C6Uj0xBYovZECk/YCM=",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha1-mXYFrSNF8n9RU5vqJldEISFcd4A=",
+      "requires": {
+        "global-prefix": "^3.0.0"
+      }
+    },
+    "global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha1-/IX3MGTfafUEIfR/iD/luRO6m5c=",
+      "requires": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4="
+    },
+    "globule": {
+      "version": "1.3.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/globule/-/globule-1.3.3.tgz",
+      "integrity": "sha1-gRkZ7qwatzROkF8uO+gKE0R5c8I=",
+      "requires": {
+        "glob": "~7.1.1",
+        "lodash": "~4.17.10",
+        "minimatch": "~3.0.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha1-Oxk+kjPwHULQs/eClLvutBj5SpA=",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha1-5BK40z9eAGWTy9PO5t+fLOu+gCo="
+    },
+    "growly": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "optional": true
+    },
+    "gzip-size": {
+      "version": "5.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/gzip-size/-/gzip-size-5.1.1.tgz",
+      "integrity": "sha1-y5vuaS+HwGErIyhAqHOQTkwTUnQ=",
+      "requires": {
+        "duplexer": "^0.1.1",
+        "pify": "^4.0.1"
+      }
+    },
+    "handle-thing": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/handle-thing/-/handle-thing-2.0.1.tgz",
+      "integrity": "sha1-hX95zjWVgMNA1DCBzGSJcNC7I04="
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha1-HwgDufjLIMD6E4It8ezds2veHv0=",
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha1-Mey9MuZIo00DDYattn1NR1R/5xA="
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has/-/has-1.0.3.tgz",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha1-ZP5qywIGc+O3jbA1pa9pqp0HsRM="
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha1-Fl0wcMADCXUqEjakeTMeOsVvFCM="
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha1-fhM4GKfTlHNPlB5zw9P5KR5liyU=",
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "hash-base": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha1-VcOB2eBuHSmXqIO0o/3f5/DTrzM=",
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY="
+        }
+      }
+    },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/he/-/he-1.2.0.tgz",
+      "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8="
+    },
+    "hex-color-regex": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
+      "integrity": "sha1-TAb8y0YC/iYCs8k9+C1+fb8aio4="
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoopy": {
+      "version": "0.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/hoopy/-/hoopy-0.1.4.tgz",
+      "integrity": "sha1-YJIH1mEQADOpqUAq096mdzgcGx0="
+    },
+    "hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha1-3/wL+aIcAiCQkPKqaUKeFBTa8/k="
+    },
+    "hpack.js": {
+      "version": "2.1.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/hpack.js/-/hpack.js-2.1.6.tgz",
+      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
+      }
+    },
+    "hsl-regex": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/hsl-regex/-/hsl-regex-1.0.0.tgz",
+      "integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4="
+    },
+    "hsla-regex": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/hsla-regex/-/hsla-regex-1.0.0.tgz",
+      "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg="
+    },
+    "html-encoding-sniffer": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+      "integrity": "sha1-QqbcT9M/ACgRduiyN1nKTk+hhfM=",
+      "requires": {
+        "whatwg-encoding": "^1.0.5"
+      }
+    },
+    "html-entities": {
+      "version": "1.4.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/html-entities/-/html-entities-1.4.0.tgz",
+      "integrity": "sha1-z70bAdKvr5rcobEK59/6uYxx0tw="
+    },
+    "html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha1-39YAJ9o2o238viNiYsAKWCJoFFM="
+    },
+    "html-minifier-terser": {
+      "version": "5.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
+      "integrity": "sha1-ki6W8fO7YIMsJjS3mIQJY4mx8FQ=",
+      "requires": {
+        "camel-case": "^4.1.1",
+        "clean-css": "^4.2.3",
+        "commander": "^4.1.1",
+        "he": "^1.2.0",
+        "param-case": "^3.0.3",
+        "relateurl": "^0.2.7",
+        "terser": "^4.6.3"
+      }
+    },
+    "html-webpack-plugin": {
+      "version": "4.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/html-webpack-plugin/-/html-webpack-plugin-4.5.0.tgz",
+      "integrity": "sha1-YlCXZQiGuX6l2uMxwyDjI49sEhw=",
+      "requires": {
+        "@types/html-minifier-terser": "^5.0.0",
+        "@types/tapable": "^1.0.5",
+        "@types/webpack": "^4.41.8",
+        "html-minifier-terser": "^5.0.1",
+        "loader-utils": "^1.2.3",
+        "lodash": "^4.17.15",
+        "pretty-error": "^2.1.1",
+        "tapable": "^1.1.3",
+        "util.promisify": "1.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        },
+        "util.promisify": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/util.promisify/-/util.promisify-1.0.0.tgz",
+          "integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
+          "requires": {
+            "define-properties": "^1.1.2",
+            "object.getownpropertydescriptors": "^2.0.3"
+          }
+        }
+      }
+    },
+    "htmlparser2": {
+      "version": "6.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha1-xNditsM3GgXb5l6UrkOp+EX7j7c=",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "1.3.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dom-serializer/-/dom-serializer-1.3.2.tgz",
+          "integrity": "sha1-YgZDfTLO767HFhgDIwx6ILwbTZE=",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domelementtype": {
+          "version": "2.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha1-mgtsJ4LtahxzI9QiZxg9+b2LHVc="
+        },
+        "domutils": {
+          "version": "2.8.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/domutils/-/domutils-2.8.0.tgz",
+          "integrity": "sha1-RDfe9dtuLR9dbuhZvZXKfQIEgTU=",
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.2.0",
+            "domhandler": "^4.2.0"
+          }
+        }
+      }
+    },
+    "http-deceiver": {
+      "version": "1.2.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
+    },
+    "http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
+      }
+    },
+    "http-parser-js": {
+      "version": "0.5.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/http-parser-js/-/http-parser-js-0.5.3.tgz",
+      "integrity": "sha1-AdJwnHnUFpi7AdTezF6dpOSgM9k="
+    },
+    "http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha1-QBVB8FNIhLv5UmAzTnL4juOXZUk=",
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha1-ioyO9/WTLM+VPClsqCkblap0qjo=",
+      "requires": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
+    "http-proxy-middleware": {
+      "version": "0.19.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+      "integrity": "sha1-GDx9xKoUeRUDBkmMIQza+WCApDo=",
+      "requires": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.11",
+        "micromatch": "^3.1.10"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "https-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha1-4qkFQqu2inYuCghQ9sntrf2FBrI=",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
+    "human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha1-xbHNFPUK6uCatsWf5jujOV/k36M="
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "icss-utils": {
+      "version": "4.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/icss-utils/-/icss-utils-4.1.1.tgz",
+      "integrity": "sha1-IRcLU3ie4nRHwvR91oMIFAP5pGc=",
+      "requires": {
+        "postcss": "^7.0.14"
+      }
+    },
+    "identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
+      "requires": {
+        "harmony-reflect": "^1.4.6"
+      }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I="
+    },
+    "iferr": {
+      "version": "0.1.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/iferr/-/iferr-0.1.5.tgz",
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
+    },
+    "ignore": {
+      "version": "5.1.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha1-8VCotQo0KJsz4i9YiavU2AFvDlc="
+    },
+    "immer": {
+      "version": "8.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/immer/-/immer-8.0.1.tgz",
+      "integrity": "sha1-nHPbaD4rOXXEJPsFcq9YiYd65lY="
+    },
+    "import-cwd": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/import-cwd/-/import-cwd-2.1.0.tgz",
+      "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
+      "requires": {
+        "import-from": "^2.1.0"
+      }
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha1-NxYsJfy566oublPVtNiM4X2eDCs=",
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "import-from": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/import-from/-/import-from-2.1.0.tgz",
+      "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
+      "requires": {
+        "resolve-from": "^3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+        }
+      }
+    },
+    "import-local": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/import-local/-/import-local-3.0.3.tgz",
+      "integrity": "sha1-TVHCxJXKk5PaJZ7Ga2LgIpICEeA=",
+      "requires": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "dependencies": {
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        }
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+    },
+    "in-publish": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/in-publish/-/in-publish-2.0.1.tgz",
+      "integrity": "sha1-lIsaU1yAMFYc6lIvc/ePS+NX4Aw="
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
+    },
+    "infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha1-xM78qo5RBRwqQLos6KPScpWvlGc="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
+    },
+    "ini": {
+      "version": "1.3.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha1-op2kJbSIBvNHZ6Tvzjlyaa8oQyw="
+    },
+    "internal-ip": {
+      "version": "4.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/internal-ip/-/internal-ip-4.3.0.tgz",
+      "integrity": "sha1-hFRSuq2dLKO2nGNaE3rLmg2tCQc=",
+      "requires": {
+        "default-gateway": "^4.2.0",
+        "ipaddr.js": "^1.9.0"
+      }
+    },
+    "internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha1-c0fjB97uovqsKsYgXUvH00ln9Zw=",
+      "requires": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      }
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha1-v/OFQ+64mEglB5/zoqjmy9RngbM="
+    },
+    "is-absolute-url": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+      "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY="
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha1-FbP4j9oB8ql/7ITKdhpWDxI++ps=",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+    },
+    "is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha1-CBR6GHW8KzIAXUHM2Ckd/8ZpHfM=",
+      "requires": {
+        "has-bigints": "^1.0.1"
+      }
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
+      "optional": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha1-XG3CACRt2TIa5LiFoRS7H3X2Nxk=",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+    },
+    "is-callable": {
+      "version": "1.2.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-callable/-/is-callable-1.2.4.tgz",
+      "integrity": "sha1-RzAdWN0CWUB4ZVR4U99tYf5HGUU="
+    },
+    "is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha1-a8YzQYGBDgS1wis9WJ/cpVAmQEw=",
+      "requires": {
+        "ci-info": "^2.0.0"
+      }
+    },
+    "is-color-stop": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-color-stop/-/is-color-stop-1.1.0.tgz",
+      "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
+      "requires": {
+        "css-color-names": "^0.0.4",
+        "hex-color-regex": "^1.1.0",
+        "hsl-regex": "^1.0.0",
+        "hsla-regex": "^1.0.0",
+        "rgb-regex": "^1.0.1",
+        "rgba-regex": "^1.0.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.8.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-core-module/-/is-core-module-2.8.0.tgz",
+      "integrity": "sha1-AyEzbD0JJeSX/Zf12VyxFKXM1Ug=",
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha1-CEHVU25yTCVZe/bqYuG9OCmN8x8=",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0="
+        }
+      }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
+    },
+    "is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha1-M+6r4jz+hvFL3kQIoCwM+4U6zao="
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+    },
+    "is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha1-kEE1x3+0LAZB1qobzbxNqo2ggvM="
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0="
+    },
+    "is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha1-fRQK3DiarzARqPKipM+m+q3/sRg="
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
+    },
+    "is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha1-PedGwY3aIxkkGlNnWQjY92bxHCQ="
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss="
+    },
+    "is-number-object": {
+      "version": "1.0.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-number-object/-/is-number-object-1.0.6.tgz",
+      "integrity": "sha1-anqvg4x/BoalC0VT9+VKlklOifA=",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha1-Rz+wXZc3BeP9liBUUBjKjiLvSYI="
+    },
+    "is-path-cwd": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha1-Z9Q7gmZKe1GR/ZEZEn6zAASKn9s="
+    },
+    "is-path-in-cwd": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+      "integrity": "sha1-v+Lcomxp85cmWkAJljYCk1oFOss=",
+      "requires": {
+        "is-path-inside": "^2.1.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-path-inside/-/is-path-inside-2.1.0.tgz",
+      "integrity": "sha1-fJgQWH1lmkDSe8201WFuqwWUlLI=",
+      "requires": {
+        "path-is-inside": "^1.0.2"
+      }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha1-Fx7W8Z46xVQ5Tt94yqBXhKRb67U="
+    },
+    "is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha1-7vVmPNWfpMCuM5UFMj32hUuxWVg=",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg="
+    },
+    "is-root": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-root/-/is-root-2.1.0.tgz",
+      "integrity": "sha1-gJ4YEpzxEpZEMCpPhUQDXVGYSpw="
+    },
+    "is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha1-l7DIX72stZycRG/mU7gs8rW3z+Y="
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-string": {
+      "version": "1.0.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha1-DdEr8gBvJVu1j2lREO/3SR7rwP0=",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha1-ptrJO2NbBjymhyI23oiRClevE5w=",
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
+    "is-weakref": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-weakref/-/is-weakref-1.0.1.tgz",
+      "integrity": "sha1-hC26TsF/qayYUN8tbvvBc3J08qI=",
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0="
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "istanbul-lib-coverage": {
+      "version": "3.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
+      "integrity": "sha1-GJ55CdCjn6Wj361bA/cZR3cBkdM="
+    },
+    "istanbul-lib-instrument": {
+      "version": "5.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/istanbul-lib-instrument/-/istanbul-lib-instrument-5.0.4.tgz",
+      "integrity": "sha1-6XbyqmbrxnN/I206sFt242+IXIA=",
+      "requires": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.0.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
+        }
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha1-dRj+UupE3jcvRgp2tezan/tz2KY=",
+      "requires": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha1-QV6WcEazp/HRhSd9hKpYIDcmoT8=",
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha1-iV86cJ/PujTG3lpCk5Ai8+Q1hVE=",
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "3.0.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/istanbul-reports/-/istanbul-reports-3.0.5.tgz",
+      "integrity": "sha1-olgBB+cSeeptZh3e3pKf/G1pM4Q=",
+      "requires": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      }
+    },
+    "jest": {
+      "version": "26.6.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest/-/jest-26.6.0.tgz",
+      "integrity": "sha1-VGslodjIiFadu+k8rhMXSAhqSiU=",
+      "requires": {
+        "@jest/core": "^26.6.0",
+        "import-local": "^3.0.2",
+        "jest-cli": "^26.6.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "jest-cli": {
+          "version": "26.6.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-cli/-/jest-cli-26.6.3.tgz",
+          "integrity": "sha1-QxF8/vJLxM1pGhdKh5alMuE16So=",
+          "requires": {
+            "@jest/core": "^26.6.3",
+            "@jest/test-result": "^26.6.2",
+            "@jest/types": "^26.6.2",
+            "chalk": "^4.0.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.4",
+            "import-local": "^3.0.2",
+            "is-ci": "^2.0.0",
+            "jest-config": "^26.6.3",
+            "jest-util": "^26.6.2",
+            "jest-validate": "^26.6.2",
+            "prompts": "^2.0.1",
+            "yargs": "^15.4.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-changed-files": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-changed-files/-/jest-changed-files-26.6.2.tgz",
+      "integrity": "sha1-9hmEeeHMZvIvmuHiKsqgtCnAQtA=",
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "execa": "^4.0.0",
+        "throat": "^5.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "execa": {
+          "version": "4.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/execa/-/execa-4.1.0.tgz",
+          "integrity": "sha1-TlSRrRVy8vF6d9OIxshXE1sihHo=",
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc="
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U="
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI="
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/which/-/which-2.0.2.tgz",
+          "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "jest-circus": {
+      "version": "26.6.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-circus/-/jest-circus-26.6.0.tgz",
+      "integrity": "sha1-fZZHsuf5IRgYafquH5CiYp/XBwU=",
+      "requires": {
+        "@babel/traverse": "^7.1.0",
+        "@jest/environment": "^26.6.0",
+        "@jest/test-result": "^26.6.0",
+        "@jest/types": "^26.6.0",
+        "@types/babel__traverse": "^7.0.4",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^0.7.0",
+        "expect": "^26.6.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^26.6.0",
+        "jest-matcher-utils": "^26.6.0",
+        "jest-message-util": "^26.6.0",
+        "jest-runner": "^26.6.0",
+        "jest-runtime": "^26.6.0",
+        "jest-snapshot": "^26.6.0",
+        "jest-util": "^26.6.0",
+        "pretty-format": "^26.6.0",
+        "stack-utils": "^2.0.2",
+        "throat": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-config": {
+      "version": "26.6.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-config/-/jest-config-26.6.3.tgz",
+      "integrity": "sha1-ZPQURO756wPcUdXFO3XIxx9kU0k=",
+      "requires": {
+        "@babel/core": "^7.1.0",
+        "@jest/test-sequencer": "^26.6.3",
+        "@jest/types": "^26.6.2",
+        "babel-jest": "^26.6.3",
+        "chalk": "^4.0.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.2.4",
+        "jest-environment-jsdom": "^26.6.2",
+        "jest-environment-node": "^26.6.2",
+        "jest-get-type": "^26.3.0",
+        "jest-jasmine2": "^26.6.3",
+        "jest-regex-util": "^26.0.0",
+        "jest-resolve": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-validate": "^26.6.2",
+        "micromatch": "^4.0.2",
+        "pretty-format": "^26.6.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "jest-resolve": {
+          "version": "26.6.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-resolve/-/jest-resolve-26.6.2.tgz",
+          "integrity": "sha1-o6sVFyF/RptQTxtWYDxbtUH7tQc=",
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "jest-pnp-resolver": "^1.2.2",
+            "jest-util": "^26.6.2",
+            "read-pkg-up": "^7.0.1",
+            "resolve": "^1.18.1",
+            "slash": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-diff": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-diff/-/jest-diff-26.6.2.tgz",
+      "integrity": "sha1-GqdGi1LDpo19XF/c381eSb0WQ5Q=",
+      "requires": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^26.6.2",
+        "jest-get-type": "^26.3.0",
+        "pretty-format": "^26.6.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-docblock": {
+      "version": "26.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-docblock/-/jest-docblock-26.0.0.tgz",
+      "integrity": "sha1-Pi+iCJn8koyxO9D/aL03EaNoibU=",
+      "requires": {
+        "detect-newline": "^3.0.0"
+      }
+    },
+    "jest-each": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-each/-/jest-each-26.6.2.tgz",
+      "integrity": "sha1-AlJkOKd6Z0AcimOC3+WZmVLBZ8s=",
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^26.3.0",
+        "jest-util": "^26.6.2",
+        "pretty-format": "^26.6.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-environment-jsdom": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-environment-jsdom/-/jest-environment-jsdom-26.6.2.tgz",
+      "integrity": "sha1-eNCf6c8BmjVwCbm34fEB0jvR2j4=",
+      "requires": {
+        "@jest/environment": "^26.6.2",
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "jest-mock": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jsdom": "^16.4.0"
+      }
+    },
+    "jest-environment-node": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-environment-node/-/jest-environment-node-26.6.2.tgz",
+      "integrity": "sha1-gk5Mf7SURkY1bxGsdbIpsANfKww=",
+      "requires": {
+        "@jest/environment": "^26.6.2",
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "jest-mock": "^26.6.2",
+        "jest-util": "^26.6.2"
+      }
+    },
+    "jest-get-type": {
+      "version": "26.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-get-type/-/jest-get-type-26.3.0.tgz",
+      "integrity": "sha1-6X3Dw/U8K0Bsp6+u1Ek7HQmRmeA="
+    },
+    "jest-haste-map": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
+      "integrity": "sha1-3X5g/n3A6fkRoj15xf9/tcLK/qo=",
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "@types/graceful-fs": "^4.1.2",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
+        "graceful-fs": "^4.2.4",
+        "jest-regex-util": "^26.0.0",
+        "jest-serializer": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-worker": "^26.6.2",
+        "micromatch": "^4.0.2",
+        "sane": "^4.0.3",
+        "walker": "^1.0.7"
+      }
+    },
+    "jest-jasmine2": {
+      "version": "26.6.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-jasmine2/-/jest-jasmine2-26.6.3.tgz",
+      "integrity": "sha1-rcPPkV3qy1ISyTufNUfNEpWPLt0=",
+      "requires": {
+        "@babel/traverse": "^7.1.0",
+        "@jest/environment": "^26.6.2",
+        "@jest/source-map": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "expect": "^26.6.2",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^26.6.2",
+        "jest-matcher-utils": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-runtime": "^26.6.3",
+        "jest-snapshot": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "pretty-format": "^26.6.2",
+        "throat": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-leak-detector": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz",
+      "integrity": "sha1-dxfPEYuSI48uumUFTIoMnGU6ka8=",
+      "requires": {
+        "jest-get-type": "^26.3.0",
+        "pretty-format": "^26.6.2"
+      }
+    },
+    "jest-matcher-utils": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz",
+      "integrity": "sha1-jm/W6GPIstMaxkcu6yN7xZXlPno=",
+      "requires": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^26.6.2",
+        "jest-get-type": "^26.3.0",
+        "pretty-format": "^26.6.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-message-util": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-message-util/-/jest-message-util-26.6.2.tgz",
+      "integrity": "sha1-WBc3RK1vwFBrXSEVC5vlbvABygc=",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@jest/types": "^26.6.2",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "micromatch": "^4.0.2",
+        "pretty-format": "^26.6.2",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-mock": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-mock/-/jest-mock-26.6.2.tgz",
+      "integrity": "sha1-1stxKwQe1H/g2bb8NHS8ZUP+swI=",
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "@types/node": "*"
+      }
+    },
+    "jest-pnp-resolver": {
+      "version": "1.2.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
+      "integrity": "sha1-twSsCuAoqJEIpNBAs/kZ393I4zw="
+    },
+    "jest-regex-util": {
+      "version": "26.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
+      "integrity": "sha1-0l5xhLNuOf1GbDvEG+CXHoIf7ig="
+    },
+    "jest-resolve": {
+      "version": "26.6.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-resolve/-/jest-resolve-26.6.0.tgz",
+      "integrity": "sha1-Bw/nFZr4ewPlD1LqXhfulbvuQOE=",
+      "requires": {
+        "@jest/types": "^26.6.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^26.6.0",
+        "read-pkg-up": "^7.0.1",
+        "resolve": "^1.17.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-resolve-dependencies": {
+      "version": "26.6.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3.tgz",
+      "integrity": "sha1-ZoCFnuXSLuXc2WH+SHH1n0x4T7Y=",
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "jest-regex-util": "^26.0.0",
+        "jest-snapshot": "^26.6.2"
+      }
+    },
+    "jest-runner": {
+      "version": "26.6.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-runner/-/jest-runner-26.6.3.tgz",
+      "integrity": "sha1-LR/tPUbhDyM/0dvTv6o/6JJL4Vk=",
+      "requires": {
+        "@jest/console": "^26.6.2",
+        "@jest/environment": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.7.1",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.4",
+        "jest-config": "^26.6.3",
+        "jest-docblock": "^26.0.0",
+        "jest-haste-map": "^26.6.2",
+        "jest-leak-detector": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-resolve": "^26.6.2",
+        "jest-runtime": "^26.6.3",
+        "jest-util": "^26.6.2",
+        "jest-worker": "^26.6.2",
+        "source-map-support": "^0.5.6",
+        "throat": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "jest-resolve": {
+          "version": "26.6.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-resolve/-/jest-resolve-26.6.2.tgz",
+          "integrity": "sha1-o6sVFyF/RptQTxtWYDxbtUH7tQc=",
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "jest-pnp-resolver": "^1.2.2",
+            "jest-util": "^26.6.2",
+            "read-pkg-up": "^7.0.1",
+            "resolve": "^1.18.1",
+            "slash": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-runtime": {
+      "version": "26.6.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-runtime/-/jest-runtime-26.6.3.tgz",
+      "integrity": "sha1-T2TvvPrDmDMbdLSzyC0n1AG4+is=",
+      "requires": {
+        "@jest/console": "^26.6.2",
+        "@jest/environment": "^26.6.2",
+        "@jest/fake-timers": "^26.6.2",
+        "@jest/globals": "^26.6.2",
+        "@jest/source-map": "^26.6.2",
+        "@jest/test-result": "^26.6.2",
+        "@jest/transform": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^0.6.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.4",
+        "jest-config": "^26.6.3",
+        "jest-haste-map": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-mock": "^26.6.2",
+        "jest-regex-util": "^26.0.0",
+        "jest-resolve": "^26.6.2",
+        "jest-snapshot": "^26.6.2",
+        "jest-util": "^26.6.2",
+        "jest-validate": "^26.6.2",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0",
+        "yargs": "^15.4.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "jest-resolve": {
+          "version": "26.6.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-resolve/-/jest-resolve-26.6.2.tgz",
+          "integrity": "sha1-o6sVFyF/RptQTxtWYDxbtUH7tQc=",
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "jest-pnp-resolver": "^1.2.2",
+            "jest-util": "^26.6.2",
+            "read-pkg-up": "^7.0.1",
+            "resolve": "^1.18.1",
+            "slash": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-serializer": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-serializer/-/jest-serializer-26.6.2.tgz",
+      "integrity": "sha1-0Tmq/UaVfTpEjzps2r4pGboHQtE=",
+      "requires": {
+        "@types/node": "*",
+        "graceful-fs": "^4.2.4"
+      }
+    },
+    "jest-snapshot": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-snapshot/-/jest-snapshot-26.6.2.tgz",
+      "integrity": "sha1-87CvGssiMxaFC9FOG+6pg3+znIQ=",
+      "requires": {
+        "@babel/types": "^7.0.0",
+        "@jest/types": "^26.6.2",
+        "@types/babel__traverse": "^7.0.4",
+        "@types/prettier": "^2.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^26.6.2",
+        "graceful-fs": "^4.2.4",
+        "jest-diff": "^26.6.2",
+        "jest-get-type": "^26.3.0",
+        "jest-haste-map": "^26.6.2",
+        "jest-matcher-utils": "^26.6.2",
+        "jest-message-util": "^26.6.2",
+        "jest-resolve": "^26.6.2",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^26.6.2",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "jest-resolve": {
+          "version": "26.6.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-resolve/-/jest-resolve-26.6.2.tgz",
+          "integrity": "sha1-o6sVFyF/RptQTxtWYDxbtUH7tQc=",
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "jest-pnp-resolver": "^1.2.2",
+            "jest-util": "^26.6.2",
+            "read-pkg-up": "^7.0.1",
+            "resolve": "^1.18.1",
+            "slash": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-util": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-util/-/jest-util-26.6.2.tgz",
+      "integrity": "sha1-kHU12+TVpstMR6ybkm9q8pV2y8E=",
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "is-ci": "^2.0.0",
+        "micromatch": "^4.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-validate": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-validate/-/jest-validate-26.6.2.tgz",
+      "integrity": "sha1-I9OAlxWHFQRnNCkRw9e0rFerIOw=",
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "camelcase": "^6.0.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^26.3.0",
+        "leven": "^3.1.0",
+        "pretty-format": "^26.6.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-watch-typeahead": {
+      "version": "0.6.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-watch-typeahead/-/jest-watch-typeahead-0.6.1.tgz",
+      "integrity": "sha1-RSIbhrtnELfpe6qhZAriSgd4XmM=",
+      "requires": {
+        "ansi-escapes": "^4.3.1",
+        "chalk": "^4.0.0",
+        "jest-regex-util": "^26.0.0",
+        "jest-watcher": "^26.3.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-watcher": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-watcher/-/jest-watcher-26.6.2.tgz",
+      "integrity": "sha1-pbaDuPnWjbyx19rjIXLSzKBZKXU=",
+      "requires": {
+        "@jest/test-result": "^26.6.2",
+        "@jest/types": "^26.6.2",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "jest-util": "^26.6.2",
+        "string-length": "^4.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-worker": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-worker/-/jest-worker-26.6.2.tgz",
+      "integrity": "sha1-f3LLxNZDw2Xie5/XdfnQ6qnHqO0=",
+      "requires": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "js-base64": {
+      "version": "2.6.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/js-base64/-/js-base64-2.6.4.tgz",
+      "integrity": "sha1-9OaGxd4eofhn28rT1G2WlCjfmMQ="
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
+    },
+    "js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha1-2ugS/bOCX6MGYJqHFzg8UMNqBTc=",
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "jsdom": {
+      "version": "16.7.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jsdom/-/jsdom-16.7.0.tgz",
+      "integrity": "sha1-kYrnGWVCSxl8gZ+Bg6dU4Yl3txA=",
+      "requires": {
+        "abab": "^2.0.5",
+        "acorn": "^8.2.4",
+        "acorn-globals": "^6.0.0",
+        "cssom": "^0.4.4",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^2.0.0",
+        "decimal.js": "^10.2.1",
+        "domexception": "^2.0.1",
+        "escodegen": "^2.0.0",
+        "form-data": "^3.0.0",
+        "html-encoding-sniffer": "^2.0.1",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.0",
+        "parse5": "6.0.1",
+        "saxes": "^5.0.1",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.0.0",
+        "w3c-hr-time": "^1.0.2",
+        "w3c-xmlserializer": "^2.0.0",
+        "webidl-conversions": "^6.1.0",
+        "whatwg-encoding": "^1.0.5",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.5.0",
+        "ws": "^7.4.6",
+        "xml-name-validator": "^3.0.0"
+      }
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q="
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk="
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha1-fEeAWpQxmSjgV3dAXcEuH3pO4C0="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "json3": {
+      "version": "3.3.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/json3/-/json3-3.3.3.tgz",
+      "integrity": "sha1-f8EON1/FrkLEcFpcwKpvYr4wW4E="
+    },
+    "json5": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha1-Lf7+cgxrpSXZ69kJlQ8FFTFsiaM=",
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha1-vFWyY0eTxnnsZAMJTrE2mKbsCq4=",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "killable": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/killable/-/killable-1.0.1.tgz",
+      "integrity": "sha1-TIzkQRh6Bhx0dPuHygjipjgZSJI="
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0="
+    },
+    "kleur": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha1-p5yezIbuHOP6YgbRIWxQHxR/wH4="
+    },
+    "last-call-webpack-plugin": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz",
+      "integrity": "sha1-l0LfDhDjz0blwDgcLekNOnotdVU=",
+      "requires": {
+        "lodash": "^4.17.5",
+        "webpack-sources": "^1.1.0"
+      }
+    },
+    "leven": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I="
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        }
+      }
+    },
+    "loader-runner": {
+      "version": "4.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/loader-runner/-/loader-runner-4.2.0.tgz",
+      "integrity": "sha1-1wIjgNZtFMX7HUlriYZOvP1Hg4Q="
+    },
+    "loader-utils": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/loader-utils/-/loader-utils-2.0.0.tgz",
+      "integrity": "sha1-5MrOW4FtQloWa18JfhDNErNgZLA=",
+      "requires": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      }
+    },
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+      "requires": {
+        "p-locate": "^4.1.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw="
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+    },
+    "lodash.template": {
+      "version": "4.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha1-+XYZXPPzR9DV9SSDVp/oAxzM6Ks=",
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha1-5IExDwSdPPbUfpEq0JMTsVTw+zM=",
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0"
+      }
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "loglevel": {
+      "version": "1.7.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/loglevel/-/loglevel-1.7.1.tgz",
+      "integrity": "sha1-AF/eL15uRwaPk1/yhXPhJe9y8Zc="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
+    "lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha1-b6I3xj29xKgsoP2ILkci3F5jTig=",
+      "requires": {
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha1-6KM1rdXOrlGqJh0ypJAVjvBC7wE="
+        }
+      }
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha1-P0l9b9NMZpxnmNy4IfLvMfVEUFE=",
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
+    "make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+      "requires": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
+        }
+      }
+    },
+    "makeerror": {
+      "version": "1.0.11",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/makeerror/-/makeerror-1.0.11.tgz",
+      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "requires": {
+        "tmpl": "1.0.x"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "mdn-data": {
+      "version": "2.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/mdn-data/-/mdn-data-2.0.4.tgz",
+      "integrity": "sha1-aZs8OKxvHXKAkaZGULZdOIUC/Vs="
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memory-fs": {
+      "version": "0.4.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/memory-fs/-/memory-fs-0.4.1.tgz",
+      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+      "requires": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "requires": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        }
+      }
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A="
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "microevent.ts": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/microevent.ts/-/microevent.ts-0.1.1.tgz",
+      "integrity": "sha1-cLCbg/Q99RctAgWmMCW84Pc1f6A="
+    },
+    "micromatch": {
+      "version": "4.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha1-iW1Rnf6dsl/OlM63pQCRm/iB6/k=",
+      "requires": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
+      }
+    },
+    "miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og="
+        }
+      }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
+    },
+    "mime-db": {
+      "version": "1.50.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/mime-db/-/mime-db-1.50.0.tgz",
+      "integrity": "sha1-q9SslOmNPA4YUBbGerRdX95AwR8="
+    },
+    "mime-types": {
+      "version": "2.1.33",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/mime-types/-/mime-types-2.1.33.tgz",
+      "integrity": "sha1-H6EqkERy+v0GjkjZ6EAfdNP3Dts=",
+      "requires": {
+        "mime-db": "1.50.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs="
+    },
+    "mini-css-extract-plugin": {
+      "version": "0.11.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/mini-css-extract-plugin/-/mini-css-extract-plugin-0.11.3.tgz",
+      "integrity": "sha1-FbCRCn8y5i/95KdDDP771wByTqY=",
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "normalize-url": "1.9.1",
+        "schema-utils": "^1.0.0",
+        "webpack-sources": "^1.1.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc="
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI="
+    },
+    "minipass": {
+      "version": "3.1.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/minipass/-/minipass-3.1.5.tgz",
+      "integrity": "sha1-cfYlGwozpJwBs8+X/3ftoDDf9zI=",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha1-IrgTv3Rdxu26JXa5QAIq1u3Ixhc=",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-flush": {
+      "version": "1.0.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/minipass-flush/-/minipass-flush-1.0.5.tgz",
+      "integrity": "sha1-gucTXX6JpQ/+ZGEKeHlTxMTLs3M=",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha1-aEcveXEcCEZXwGfFxq2Tzd6oIUw=",
+      "requires": {
+        "minipass": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha1-6Q00Zrogm5MkUVCKEc49NjIUWTE=",
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      }
+    },
+    "mississippi": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/mississippi/-/mississippi-3.0.0.tgz",
+      "integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
+      "requires": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^3.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      }
+    },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "move-concurrently": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+      "requires": {
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+    },
+    "multicast-dns": {
+      "version": "6.2.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/multicast-dns/-/multicast-dns-6.2.3.tgz",
+      "integrity": "sha1-oOx72QVcQoL3kMPIL04o2zsxsik=",
+      "requires": {
+        "dns-packet": "^1.3.1",
+        "thunky": "^1.0.2"
+      }
+    },
+    "multicast-dns-service-types": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+      "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+    },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha1-PzSkc/8Y4VwbVia2KQO1rW5mX+4="
+    },
+    "nanoid": {
+      "version": "3.1.30",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/nanoid/-/nanoid-3.1.30.tgz",
+      "integrity": "sha1-Y/k8xUjSoRPcXfvGO/oJ4rm2Q2I="
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
+    },
+    "native-url": {
+      "version": "0.2.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/native-url/-/native-url-0.2.6.tgz",
+      "integrity": "sha1-yhJY9azhaccW/0Tsy922dOEDma4=",
+      "requires": {
+        "querystring": "^0.2.0"
+      }
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha1-/qz3zPUlp3rpY0Q2pkiD/+yjRvs="
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8="
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y="
+    },
+    "no-case": {
+      "version": "3.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha1-02H9XJgA9VhVGoNp/A3NRmK2Ek0=",
+      "requires": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha1-6KM1rdXOrlGqJh0ypJAVjvBC7wE="
+        }
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha1-mA9vcthSEaU0fGsrwYxbhMPrR+8=",
+      "dev": true,
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
+    },
+    "node-forge": {
+      "version": "0.10.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha1-Mt6ir7Ppkm8C7lzoeUkCaRpna/M="
+    },
+    "node-gyp": {
+      "version": "3.8.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/node-gyp/-/node-gyp-3.8.0.tgz",
+      "integrity": "sha1-VAMEJhwzDoDQ1e3OJTpoyzlkIYw=",
+      "requires": {
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "^2.87.0",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+        }
+      }
+    },
+    "node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+    },
+    "node-libs-browser": {
+      "version": "2.2.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+      "integrity": "sha1-tk9RPRgzhiX5A0bSew0jXmMfZCU=",
+      "requires": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^3.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
+        "path-browserify": "0.0.1",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
+        "tty-browserify": "0.0.0",
+        "url": "^0.11.0",
+        "util": "^0.11.0",
+        "vm-browserify": "^1.0.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
+      }
+    },
+    "node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA="
+    },
+    "node-notifier": {
+      "version": "8.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/node-notifier/-/node-notifier-8.0.2.tgz",
+      "integrity": "sha1-8xZ6OO8NLIqGaoPjGMG6Dv63AsU=",
+      "optional": true,
+      "requires": {
+        "growly": "^1.3.0",
+        "is-wsl": "^2.2.0",
+        "semver": "^7.3.2",
+        "shellwords": "^0.1.1",
+        "uuid": "^8.3.0",
+        "which": "^2.0.2"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/which/-/which-2.0.2.tgz",
+          "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+          "optional": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "node-releases": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/node-releases/-/node-releases-2.0.0.tgz",
+      "integrity": "sha1-Z9x0kDEAp96wRAN7ii5fRTuwVAA="
+    },
+    "node-sass": {
+      "version": "4.14.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/node-sass/-/node-sass-4.14.1.tgz",
+      "integrity": "sha1-mch+wu+3BH7WOPtMnbfzpC4iF7U=",
+      "requires": {
+        "async-foreach": "^0.1.3",
+        "chalk": "^1.1.1",
+        "cross-spawn": "^3.0.0",
+        "gaze": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "glob": "^7.0.3",
+        "in-publish": "^2.0.0",
+        "lodash": "^4.17.15",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.13.2",
+        "node-gyp": "^3.8.0",
+        "npmlog": "^4.0.0",
+        "request": "^2.88.0",
+        "sass-graph": "2.2.5",
+        "stdout-stream": "^1.4.0",
+        "true-case-path": "^1.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "3.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cross-spawn/-/cross-spawn-3.0.1.tgz",
+          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
+        }
+      }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU="
+    },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+    },
+    "normalize-url": {
+      "version": "1.9.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/normalize-url/-/normalize-url-1.9.1.tgz",
+      "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+      "requires": {
+        "object-assign": "^4.0.1",
+        "prepend-http": "^1.0.0",
+        "query-string": "^4.1.0",
+        "sort-keys": "^1.0.0"
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha1-sr0pXDfj3VijvwcAN2Zjuk2c8Fw=",
+      "requires": {
+        "boolbase": "~1.0.0"
+      }
+    },
+    "num2fraction": {
+      "version": "1.2.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/num2fraction/-/num2fraction-1.2.2.tgz",
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "nwsapi": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/nwsapi/-/nwsapi-2.2.0.tgz",
+      "integrity": "sha1-IEh5qePQaP8qVROcLHcngGgaOLc="
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-inspect": {
+      "version": "1.11.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/object-inspect/-/object-inspect-1.11.0.tgz",
+      "integrity": "sha1-nc6xRs7dQUig2eUauI00z1CZIrE="
+    },
+    "object-is": {
+      "version": "1.1.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha1-ud7qpfx/GEag+uzc7sE45XePU6w=",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4="
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha1-DtVKNC7Os3s4/3brgxoOeIy2OUA=",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/object.entries/-/object.entries-1.1.5.tgz",
+      "integrity": "sha1-4azdF8TeLNltWghIfPuduE2IGGE=",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.1.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.3.tgz",
+      "integrity": "sha1-siPPOOF/77l6Y8EMkd9yzLOG354=",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "object.values": {
+      "version": "1.1.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/object.values/-/object.values-1.1.5.tgz",
+      "integrity": "sha1-lZ9j486e8QhyAzMIITHkpFm3Fqw=",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
+    "obuf": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha1-Cb6jND1BhZ69RGKS0RydTbYZCE4="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha1-dysK5qqlJcOZ5Imt+tkMQD6zwo8="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "5.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "open": {
+      "version": "7.4.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/open/-/open-7.4.2.tgz",
+      "integrity": "sha1-uBR+Jtzz5CYxbHMAif1x7dKcIyE=",
+      "requires": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      }
+    },
+    "opn": {
+      "version": "5.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/opn/-/opn-5.5.0.tgz",
+      "integrity": "sha1-/HFk+rVtI1kExRw7J9pnWMo7m/w=",
+      "requires": {
+        "is-wsl": "^1.1.0"
+      },
+      "dependencies": {
+        "is-wsl": {
+          "version": "1.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-wsl/-/is-wsl-1.1.0.tgz",
+          "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+        }
+      }
+    },
+    "optimize-css-assets-webpack-plugin": {
+      "version": "5.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.4.tgz",
+      "integrity": "sha1-hYg8ZSiqoC4wu62ZCMkpJrtS3JA=",
+      "requires": {
+        "cssnano": "^4.1.10",
+        "last-call-webpack-plugin": "^3.0.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha1-hPodA2/p08fiHZmIS2ARZ+yPtJU=",
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
+    "original": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/original/-/original-1.0.2.tgz",
+      "integrity": "sha1-5EKmHP/hxf0gpl8yYcJmY7MD8l8=",
+      "requires": {
+        "url-parse": "^1.4.3"
+      }
+    },
+    "os-browserify": {
+      "version": "0.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "p-each-series": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/p-each-series/-/p-each-series-2.2.0.tgz",
+      "integrity": "sha1-EFqwNXznKyAqiouUkzZyZXteKpo="
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-map": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha1-uy+Vpe2i7BaOySdOBqdHw+KQTSs=",
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
+    },
+    "p-retry": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/p-retry/-/p-retry-3.0.1.tgz",
+      "integrity": "sha1-MWtMiJPiyNwc+okfQGxLQivr8yg=",
+      "requires": {
+        "retry": "^0.12.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
+    },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8="
+    },
+    "parallel-transform": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/parallel-transform/-/parallel-transform-1.2.0.tgz",
+      "integrity": "sha1-kEnKN9bLIYLDsdLHIL6U0UpYFPw=",
+      "requires": {
+        "cyclist": "^1.0.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
+      }
+    },
+    "param-case": {
+      "version": "3.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha1-fRf+SqEr3jTUp32RrPtiGcqtAcU=",
+      "requires": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha1-6KM1rdXOrlGqJh0ypJAVjvBC7wE="
+        }
+      }
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "parse-asn1": {
+      "version": "5.1.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/parse-asn1/-/parse-asn1-5.1.6.tgz",
+      "integrity": "sha1-OFCAo+wTy2KmLTlAnLPoiETNrtQ=",
+      "requires": {
+        "asn1.js": "^5.2.0",
+        "browserify-aes": "^1.0.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha1-x2/Gbe5UIxyWKyK8yKcs8vmXU80=",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      }
+    },
+    "parse5": {
+      "version": "6.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha1-4aHAhcVps9wIMhGE8Zo5zCf3wws="
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ="
+    },
+    "pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha1-tI4O8rmOIF58Ha50fQsVCCN2YOs=",
+      "requires": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha1-6KM1rdXOrlGqJh0ypJAVjvBC7wE="
+        }
+      }
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+    },
+    "path-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha1-5sTd1+06onxoogzE5Q4aTug7vEo="
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs="
+    },
+    "pbkdf2": {
+      "version": "3.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha1-3YIqoIh1gOUvGgOdw+2hCO+uMHU=",
+      "requires": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha1-y1vcdP8/UYkiNur3nWi8RFZKuBw="
+    },
+    "picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha1-8fBh3o9qS/AiiS4tEoI0+5gwKXI="
+    },
+    "pify": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE="
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "pirates": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pirates/-/pirates-4.0.1.tgz",
+      "integrity": "sha1-ZDqSyviUVm+RsrmG0sZpUKji+4c=",
+      "requires": {
+        "node-modules-regexp": "^1.0.0"
+      }
+    },
+    "pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
+      "requires": {
+        "find-up": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        }
+      }
+    },
+    "pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha1-EA7CNcwVDk/UJRlBJZaihRKg3vU=",
+      "requires": {
+        "find-up": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        }
+      }
+    },
+    "pnp-webpack-plugin": {
+      "version": "1.6.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz",
+      "integrity": "sha1-yXEaxNxIpoXauvyG+Lbdn434QUk=",
+      "requires": {
+        "ts-pnp": "^1.1.6"
+      }
+    },
+    "portfinder": {
+      "version": "1.0.28",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/portfinder/-/portfinder-1.0.28.tgz",
+      "integrity": "sha1-Z8RiKFK9U3TdHdkA93n1NGL6x3g=",
+      "requires": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+    },
+    "postcss": {
+      "version": "7.0.39",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss/-/postcss-7.0.39.tgz",
+      "integrity": "sha1-liQ3XZZWMOLh8sAqk1yCpZy0gwk=",
+      "requires": {
+        "picocolors": "^0.2.1",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "picocolors": {
+          "version": "0.2.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/picocolors/-/picocolors-0.2.1.tgz",
+          "integrity": "sha1-VwZw95NkaFHRuhNZlpYqutWHhZ8="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        }
+      }
+    },
+    "postcss-attribute-case-insensitive": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.2.tgz",
+      "integrity": "sha1-2T5GtQRYnpSscnewRjImxoBBqIA=",
+      "requires": {
+        "postcss": "^7.0.2",
+        "postcss-selector-parser": "^6.0.2"
+      }
+    },
+    "postcss-browser-comments": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-browser-comments/-/postcss-browser-comments-3.0.0.tgz",
+      "integrity": "sha1-EkjS2TX7cgU8jh9hqEpXKS2fZek=",
+      "requires": {
+        "postcss": "^7"
+      }
+    },
+    "postcss-calc": {
+      "version": "7.0.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-calc/-/postcss-calc-7.0.5.tgz",
+      "integrity": "sha1-+KbpnxLmGcLrwjz2xIb9wVhgkz4=",
+      "requires": {
+        "postcss": "^7.0.27",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.0.2"
+      }
+    },
+    "postcss-color-functional-notation": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-color-functional-notation/-/postcss-color-functional-notation-2.0.1.tgz",
+      "integrity": "sha1-Xv03qI+6vrAKKWbR5T2Yztk/dOA=",
+      "requires": {
+        "postcss": "^7.0.2",
+        "postcss-values-parser": "^2.0.0"
+      }
+    },
+    "postcss-color-gray": {
+      "version": "5.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-color-gray/-/postcss-color-gray-5.0.0.tgz",
+      "integrity": "sha1-Uyox65CfjaiYzv/ilv3B+GS+hUc=",
+      "requires": {
+        "@csstools/convert-colors": "^1.4.0",
+        "postcss": "^7.0.5",
+        "postcss-values-parser": "^2.0.0"
+      }
+    },
+    "postcss-color-hex-alpha": {
+      "version": "5.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.3.tgz",
+      "integrity": "sha1-qNnKTDnUl8lmHjdLnFGJnvD4c4g=",
+      "requires": {
+        "postcss": "^7.0.14",
+        "postcss-values-parser": "^2.0.1"
+      }
+    },
+    "postcss-color-mod-function": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-color-mod-function/-/postcss-color-mod-function-3.0.3.tgz",
+      "integrity": "sha1-gWuhRawRzDy2uqkFp1pJ+QPk0x0=",
+      "requires": {
+        "@csstools/convert-colors": "^1.4.0",
+        "postcss": "^7.0.2",
+        "postcss-values-parser": "^2.0.0"
+      }
+    },
+    "postcss-color-rebeccapurple": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-4.0.1.tgz",
+      "integrity": "sha1-x6ib6HK7dORbHjAiv+V0iCPm3nc=",
+      "requires": {
+        "postcss": "^7.0.2",
+        "postcss-values-parser": "^2.0.0"
+      }
+    },
+    "postcss-colormin": {
+      "version": "4.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-colormin/-/postcss-colormin-4.0.3.tgz",
+      "integrity": "sha1-rgYLzpPteUrHEmTwgTLVUJVr04E=",
+      "requires": {
+        "browserslist": "^4.0.0",
+        "color": "^3.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE="
+        }
+      }
+    },
+    "postcss-convert-values": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
+      "integrity": "sha1-yjgT7U2g+BL51DcDWE5Enr4Ymn8=",
+      "requires": {
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE="
+        }
+      }
+    },
+    "postcss-custom-media": {
+      "version": "7.0.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-custom-media/-/postcss-custom-media-7.0.8.tgz",
+      "integrity": "sha1-//0T/+/61zYhvl84cHaiiwApTgw=",
+      "requires": {
+        "postcss": "^7.0.14"
+      }
+    },
+    "postcss-custom-properties": {
+      "version": "8.0.11",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-custom-properties/-/postcss-custom-properties-8.0.11.tgz",
+      "integrity": "sha1-LWF3LW6S8i9eDVJgLfj65G+jDZc=",
+      "requires": {
+        "postcss": "^7.0.17",
+        "postcss-values-parser": "^2.0.1"
+      }
+    },
+    "postcss-custom-selectors": {
+      "version": "5.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-custom-selectors/-/postcss-custom-selectors-5.1.2.tgz",
+      "integrity": "sha1-ZIWMbrLs/y+0HQsoyd17PbTef7o=",
+      "requires": {
+        "postcss": "^7.0.2",
+        "postcss-selector-parser": "^5.0.0-rc.3"
+      },
+      "dependencies": {
+        "cssesc": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha1-OxO9G7HLNuG8taTc0n9UxdyzVwM="
+        },
+        "postcss-selector-parser": {
+          "version": "5.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "integrity": "sha1-JJBENWaXsztk8aj3yAki3d7nGVw=",
+          "requires": {
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
+      }
+    },
+    "postcss-dir-pseudo-class": {
+      "version": "5.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-5.0.0.tgz",
+      "integrity": "sha1-bjpBd9Dts6vMhf22+7HCbauuq6I=",
+      "requires": {
+        "postcss": "^7.0.2",
+        "postcss-selector-parser": "^5.0.0-rc.3"
+      },
+      "dependencies": {
+        "cssesc": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha1-OxO9G7HLNuG8taTc0n9UxdyzVwM="
+        },
+        "postcss-selector-parser": {
+          "version": "5.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "integrity": "sha1-JJBENWaXsztk8aj3yAki3d7nGVw=",
+          "requires": {
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
+      }
+    },
+    "postcss-discard-comments": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz",
+      "integrity": "sha1-H7q9LCRr/2qq15l7KwkY9NevQDM=",
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-discard-duplicates": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
+      "integrity": "sha1-P+EzzTyCKC5VD8myORdqkge3hOs=",
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-discard-empty": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
+      "integrity": "sha1-yMlR6fc+2UKAGUWERKAq2Qu592U=",
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-discard-overridden": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
+      "integrity": "sha1-ZSrvipZybwKfXj4AFG7npOdV/1c=",
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-double-position-gradients": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-double-position-gradients/-/postcss-double-position-gradients-1.0.0.tgz",
+      "integrity": "sha1-/JJ9Uv3ciWyzooEuvF3xR+EQUi4=",
+      "requires": {
+        "postcss": "^7.0.5",
+        "postcss-values-parser": "^2.0.0"
+      }
+    },
+    "postcss-env-function": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-env-function/-/postcss-env-function-2.0.2.tgz",
+      "integrity": "sha1-Dz49PFfwlKksK69LYkHwsNpTZdc=",
+      "requires": {
+        "postcss": "^7.0.2",
+        "postcss-values-parser": "^2.0.0"
+      }
+    },
+    "postcss-flexbugs-fixes": {
+      "version": "4.2.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.2.1.tgz",
+      "integrity": "sha1-khimUknzCJfeqxAzrO2FeFYqZpA=",
+      "requires": {
+        "postcss": "^7.0.26"
+      }
+    },
+    "postcss-focus-visible": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-focus-visible/-/postcss-focus-visible-4.0.0.tgz",
+      "integrity": "sha1-R30QcROt5gJLFBKDF63ivR4XBG4=",
+      "requires": {
+        "postcss": "^7.0.2"
+      }
+    },
+    "postcss-focus-within": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-focus-within/-/postcss-focus-within-3.0.0.tgz",
+      "integrity": "sha1-djuHiFls7puHTJmSAc3egGWe9oA=",
+      "requires": {
+        "postcss": "^7.0.2"
+      }
+    },
+    "postcss-font-variant": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-font-variant/-/postcss-font-variant-4.0.1.tgz",
+      "integrity": "sha1-QtTAqzCJT2D5ixdWHrXAMh9QJkE=",
+      "requires": {
+        "postcss": "^7.0.2"
+      }
+    },
+    "postcss-gap-properties": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-gap-properties/-/postcss-gap-properties-2.0.0.tgz",
+      "integrity": "sha1-QxwZKrPtlqPD0J8v9hWWD5AsFxU=",
+      "requires": {
+        "postcss": "^7.0.2"
+      }
+    },
+    "postcss-image-set-function": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-image-set-function/-/postcss-image-set-function-3.0.1.tgz",
+      "integrity": "sha1-KJIKLymUW+1MMZjX32SW1BDT8og=",
+      "requires": {
+        "postcss": "^7.0.2",
+        "postcss-values-parser": "^2.0.0"
+      }
+    },
+    "postcss-initial": {
+      "version": "3.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-initial/-/postcss-initial-3.0.4.tgz",
+      "integrity": "sha1-nTIGmhBTH+Lsr6C2rHUO4Lx+/FM=",
+      "requires": {
+        "postcss": "^7.0.2"
+      }
+    },
+    "postcss-lab-function": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-lab-function/-/postcss-lab-function-2.0.1.tgz",
+      "integrity": "sha1-u1GmhWzRIomrSuINseOCHvE9fS4=",
+      "requires": {
+        "@csstools/convert-colors": "^1.4.0",
+        "postcss": "^7.0.2",
+        "postcss-values-parser": "^2.0.0"
+      }
+    },
+    "postcss-load-config": {
+      "version": "2.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-load-config/-/postcss-load-config-2.1.2.tgz",
+      "integrity": "sha1-xepQTyxK7zPHNZo03jVzdyrXUCo=",
+      "requires": {
+        "cosmiconfig": "^5.0.0",
+        "import-cwd": "^2.0.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "5.2.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+          "integrity": "sha1-BA9yaAnFked6F8CjYmykW08Wixo=",
+          "requires": {
+            "import-fresh": "^2.0.0",
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.13.1",
+            "parse-json": "^4.0.0"
+          }
+        },
+        "import-fresh": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/import-fresh/-/import-fresh-2.0.0.tgz",
+          "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+          "requires": {
+            "caller-path": "^2.0.0",
+            "resolve-from": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+        }
+      }
+    },
+    "postcss-loader": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-loader/-/postcss-loader-3.0.0.tgz",
+      "integrity": "sha1-a5eUPkfHLYRfqeA/Jzdz1OjdbC0=",
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "postcss": "^7.0.0",
+        "postcss-load-config": "^2.0.0",
+        "schema-utils": "^1.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
+    },
+    "postcss-logical": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-logical/-/postcss-logical-3.0.0.tgz",
+      "integrity": "sha1-JJXQ+LgunyYnJfdflAGzTntF1bU=",
+      "requires": {
+        "postcss": "^7.0.2"
+      }
+    },
+    "postcss-media-minmax": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-media-minmax/-/postcss-media-minmax-4.0.0.tgz",
+      "integrity": "sha1-t1u2y8IXyKxJQz4S8iBIgUpPXtU=",
+      "requires": {
+        "postcss": "^7.0.2"
+      }
+    },
+    "postcss-merge-longhand": {
+      "version": "4.0.11",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",
+      "integrity": "sha1-YvSaE+Sg7gTnuY9CuxYGLKJUniQ=",
+      "requires": {
+        "css-color-names": "0.0.4",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "stylehacks": "^4.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE="
+        }
+      }
+    },
+    "postcss-merge-rules": {
+      "version": "4.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz",
+      "integrity": "sha1-NivqT/Wh+Y5AdacTxsslrv75plA=",
+      "requires": {
+        "browserslist": "^4.0.0",
+        "caniuse-api": "^3.0.0",
+        "cssnano-util-same-parent": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0",
+        "vendors": "^1.0.0"
+      },
+      "dependencies": {
+        "postcss-selector-parser": {
+          "version": "3.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+          "integrity": "sha1-sxD1xMD9r3b5SQK7qjDbaqhPUnA=",
+          "requires": {
+            "dot-prop": "^5.2.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
+      }
+    },
+    "postcss-minify-font-values": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
+      "integrity": "sha1-zUw0TM5HQ0P6xdgiBqssvLiv1aY=",
+      "requires": {
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE="
+        }
+      }
+    },
+    "postcss-minify-gradients": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-minify-gradients/-/postcss-minify-gradients-4.0.2.tgz",
+      "integrity": "sha1-k7KcL/UJnFNe7NpWxKpuZlpmNHE=",
+      "requires": {
+        "cssnano-util-get-arguments": "^4.0.0",
+        "is-color-stop": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE="
+        }
+      }
+    },
+    "postcss-minify-params": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-minify-params/-/postcss-minify-params-4.0.2.tgz",
+      "integrity": "sha1-a5zvAwwR41Jh+V9hjJADbWgNuHQ=",
+      "requires": {
+        "alphanum-sort": "^1.0.0",
+        "browserslist": "^4.0.0",
+        "cssnano-util-get-arguments": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "uniqs": "^2.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE="
+        }
+      }
+    },
+    "postcss-minify-selectors": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz",
+      "integrity": "sha1-4uXrQL/uUA0M2SQ1APX46kJi+9g=",
+      "requires": {
+        "alphanum-sort": "^1.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-selector-parser": {
+          "version": "3.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+          "integrity": "sha1-sxD1xMD9r3b5SQK7qjDbaqhPUnA=",
+          "requires": {
+            "dot-prop": "^5.2.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
+      }
+    },
+    "postcss-modules-extract-imports": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+      "integrity": "sha1-gYcZoa4doyX5gyRGsBE27rSTzX4=",
+      "requires": {
+        "postcss": "^7.0.5"
+      }
+    },
+    "postcss-modules-local-by-default": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz",
+      "integrity": "sha1-uxTgzHgnnVBNvcv9fgyiiZP/u7A=",
+      "requires": {
+        "icss-utils": "^4.1.1",
+        "postcss": "^7.0.32",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz",
+      "integrity": "sha1-OFyuATzHdD9afXYC0Qc6iequYu4=",
+      "requires": {
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^6.0.0"
+      }
+    },
+    "postcss-modules-values": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
+      "integrity": "sha1-W1AA1uuuKbQlUwG0o6VFdEI+fxA=",
+      "requires": {
+        "icss-utils": "^4.0.0",
+        "postcss": "^7.0.6"
+      }
+    },
+    "postcss-nesting": {
+      "version": "7.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-nesting/-/postcss-nesting-7.0.1.tgz",
+      "integrity": "sha1-tQrXt/AXPlteOIDDUBNEcD4EwFI=",
+      "requires": {
+        "postcss": "^7.0.2"
+      }
+    },
+    "postcss-normalize": {
+      "version": "8.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-normalize/-/postcss-normalize-8.0.1.tgz",
+      "integrity": "sha1-kOgKd2PX/fLaby8Pgr6DLOT2Z3Y=",
+      "requires": {
+        "@csstools/normalize.css": "^10.1.0",
+        "browserslist": "^4.6.2",
+        "postcss": "^7.0.17",
+        "postcss-browser-comments": "^3.0.0",
+        "sanitize.css": "^10.0.0"
+      }
+    },
+    "postcss-normalize-charset": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
+      "integrity": "sha1-izWt067oOhNrBHHg1ZvlilAoXdQ=",
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-normalize-display-values": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz",
+      "integrity": "sha1-Db4EpM6QY9RmftK+R2u4MMglk1o=",
+      "requires": {
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE="
+        }
+      }
+    },
+    "postcss-normalize-positions": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz",
+      "integrity": "sha1-BfdX+E8mBDc3g2ipH4ky1LECkX8=",
+      "requires": {
+        "cssnano-util-get-arguments": "^4.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE="
+        }
+      }
+    },
+    "postcss-normalize-repeat-style": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.2.tgz",
+      "integrity": "sha1-xOu8KJ85kaAo1EdRy90RkYsXkQw=",
+      "requires": {
+        "cssnano-util-get-arguments": "^4.0.0",
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE="
+        }
+      }
+    },
+    "postcss-normalize-string": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz",
+      "integrity": "sha1-zUTECrB6DHo23F6Zqs4eyk7CaQw=",
+      "requires": {
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE="
+        }
+      }
+    },
+    "postcss-normalize-timing-functions": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.2.tgz",
+      "integrity": "sha1-jgCcoqOUnNr4rSPmtquZy159KNk=",
+      "requires": {
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE="
+        }
+      }
+    },
+    "postcss-normalize-unicode": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
+      "integrity": "sha1-hBvUj9zzAZrUuqdJOj02O1KuHPs=",
+      "requires": {
+        "browserslist": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE="
+        }
+      }
+    },
+    "postcss-normalize-url": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
+      "integrity": "sha1-EOQ3+GvHx+WPe5ZS7YeNqqlfquE=",
+      "requires": {
+        "is-absolute-url": "^2.0.0",
+        "normalize-url": "^3.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "normalize-url": {
+          "version": "3.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/normalize-url/-/normalize-url-3.3.0.tgz",
+          "integrity": "sha1-suHE3E98bVd0PfczpPWXjRhlBVk="
+        },
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE="
+        }
+      }
+    },
+    "postcss-normalize-whitespace": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz",
+      "integrity": "sha1-vx1AcP5Pzqh9E0joJdjMDF+qfYI=",
+      "requires": {
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE="
+        }
+      }
+    },
+    "postcss-ordered-values": {
+      "version": "4.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz",
+      "integrity": "sha1-DPdcgg7H1cTSgBiVWeC1ceusDu4=",
+      "requires": {
+        "cssnano-util-get-arguments": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE="
+        }
+      }
+    },
+    "postcss-overflow-shorthand": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-overflow-shorthand/-/postcss-overflow-shorthand-2.0.0.tgz",
+      "integrity": "sha1-MezzUOnG9t3CUKePDD4RHzLdTDA=",
+      "requires": {
+        "postcss": "^7.0.2"
+      }
+    },
+    "postcss-page-break": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-page-break/-/postcss-page-break-2.0.0.tgz",
+      "integrity": "sha1-rdUtDgpSjKvmr+6LRuKrsnffRr8=",
+      "requires": {
+        "postcss": "^7.0.2"
+      }
+    },
+    "postcss-place": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-place/-/postcss-place-4.0.1.tgz",
+      "integrity": "sha1-6fOdM9LcWE5G7h20Wtt3yp0dzGI=",
+      "requires": {
+        "postcss": "^7.0.2",
+        "postcss-values-parser": "^2.0.0"
+      }
+    },
+    "postcss-preset-env": {
+      "version": "6.7.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-preset-env/-/postcss-preset-env-6.7.0.tgz",
+      "integrity": "sha1-w03az4+QI4OzWtHgMPF49M3xGKU=",
+      "requires": {
+        "autoprefixer": "^9.6.1",
+        "browserslist": "^4.6.4",
+        "caniuse-lite": "^1.0.30000981",
+        "css-blank-pseudo": "^0.1.4",
+        "css-has-pseudo": "^0.10.0",
+        "css-prefers-color-scheme": "^3.1.1",
+        "cssdb": "^4.4.0",
+        "postcss": "^7.0.17",
+        "postcss-attribute-case-insensitive": "^4.0.1",
+        "postcss-color-functional-notation": "^2.0.1",
+        "postcss-color-gray": "^5.0.0",
+        "postcss-color-hex-alpha": "^5.0.3",
+        "postcss-color-mod-function": "^3.0.3",
+        "postcss-color-rebeccapurple": "^4.0.1",
+        "postcss-custom-media": "^7.0.8",
+        "postcss-custom-properties": "^8.0.11",
+        "postcss-custom-selectors": "^5.1.2",
+        "postcss-dir-pseudo-class": "^5.0.0",
+        "postcss-double-position-gradients": "^1.0.0",
+        "postcss-env-function": "^2.0.2",
+        "postcss-focus-visible": "^4.0.0",
+        "postcss-focus-within": "^3.0.0",
+        "postcss-font-variant": "^4.0.0",
+        "postcss-gap-properties": "^2.0.0",
+        "postcss-image-set-function": "^3.0.1",
+        "postcss-initial": "^3.0.0",
+        "postcss-lab-function": "^2.0.1",
+        "postcss-logical": "^3.0.0",
+        "postcss-media-minmax": "^4.0.0",
+        "postcss-nesting": "^7.0.0",
+        "postcss-overflow-shorthand": "^2.0.0",
+        "postcss-page-break": "^2.0.0",
+        "postcss-place": "^4.0.1",
+        "postcss-pseudo-class-any-link": "^6.0.0",
+        "postcss-replace-overflow-wrap": "^3.0.0",
+        "postcss-selector-matches": "^4.0.0",
+        "postcss-selector-not": "^4.0.0"
+      }
+    },
+    "postcss-pseudo-class-any-link": {
+      "version": "6.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-6.0.0.tgz",
+      "integrity": "sha1-LtPu05OzcCh53sSocDKyENrrBNE=",
+      "requires": {
+        "postcss": "^7.0.2",
+        "postcss-selector-parser": "^5.0.0-rc.3"
+      },
+      "dependencies": {
+        "cssesc": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha1-OxO9G7HLNuG8taTc0n9UxdyzVwM="
+        },
+        "postcss-selector-parser": {
+          "version": "5.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "integrity": "sha1-JJBENWaXsztk8aj3yAki3d7nGVw=",
+          "requires": {
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
+      }
+    },
+    "postcss-reduce-initial": {
+      "version": "4.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
+      "integrity": "sha1-f9QuvqXpyBRgljniwuhK4nC6SN8=",
+      "requires": {
+        "browserslist": "^4.0.0",
+        "caniuse-api": "^3.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-reduce-transforms": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz",
+      "integrity": "sha1-F++kBerMbge+NBSlyi0QdGgdTik=",
+      "requires": {
+        "cssnano-util-get-match": "^4.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE="
+        }
+      }
+    },
+    "postcss-replace-overflow-wrap": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-3.0.0.tgz",
+      "integrity": "sha1-YbNg/9rtyoTHyRjSsPDQ6lWasBw=",
+      "requires": {
+        "postcss": "^7.0.2"
+      }
+    },
+    "postcss-safe-parser": {
+      "version": "5.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-safe-parser/-/postcss-safe-parser-5.0.2.tgz",
+      "integrity": "sha1-RZ3Sffa8K6ZGCIJLo55F2s9ehS0=",
+      "requires": {
+        "postcss": "^8.1.0"
+      },
+      "dependencies": {
+        "picocolors": {
+          "version": "0.2.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/picocolors/-/picocolors-0.2.1.tgz",
+          "integrity": "sha1-VwZw95NkaFHRuhNZlpYqutWHhZ8="
+        },
+        "postcss": {
+          "version": "8.3.9",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss/-/postcss-8.3.9.tgz",
+          "integrity": "sha1-mHVMqgbE7p61nMSL0HO7a9NDfDE=",
+          "requires": {
+            "nanoid": "^3.1.28",
+            "picocolors": "^0.2.1",
+            "source-map-js": "^0.6.2"
+          }
+        }
+      }
+    },
+    "postcss-selector-matches": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-selector-matches/-/postcss-selector-matches-4.0.0.tgz",
+      "integrity": "sha1-ccgkj5F7osyTA3yWN+4JxkQ2/P8=",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "postcss": "^7.0.2"
+      }
+    },
+    "postcss-selector-not": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-selector-not/-/postcss-selector-not-4.0.1.tgz",
+      "integrity": "sha1-JjAW7vHPIZ4K3pqRN4D8H0ggTL8=",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "postcss": "^7.0.2"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "6.0.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
+      "integrity": "sha1-LFu6gXSsL2mBq2MaQqsO5UrzMuo=",
+      "requires": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      }
+    },
+    "postcss-svgo": {
+      "version": "4.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-svgo/-/postcss-svgo-4.0.3.tgz",
+      "integrity": "sha1-NDos26yVBdQWJD1Jb3JPOIlMlB4=",
+      "requires": {
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "svgo": "^1.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE="
+        }
+      }
+    },
+    "postcss-unique-selectors": {
+      "version": "4.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
+      "integrity": "sha1-lEaRHzKJv9ZMbWgPBzwDsfnuS6w=",
+      "requires": {
+        "alphanum-sort": "^1.0.0",
+        "postcss": "^7.0.0",
+        "uniqs": "^2.0.0"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "4.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+      "integrity": "sha1-RD9qIM7WSBor2k+oUypuVdeJoss="
+    },
+    "postcss-values-parser": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
+      "integrity": "sha1-2otHLZAdoeIFtHvcmGN7np5VDl8=",
+      "requires": {
+        "flatten": "^1.0.2",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      }
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+    },
+    "pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha1-NWJW9kOAR3PIL2RyP+eMksYr6us="
+    },
+    "pretty-error": {
+      "version": "2.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pretty-error/-/pretty-error-2.1.2.tgz",
+      "integrity": "sha1-von4LYGxyG7I/fvDhQRYgnJ/k7Y=",
+      "requires": {
+        "lodash": "^4.17.20",
+        "renderkid": "^2.0.4"
+      }
+    },
+    "pretty-format": {
+      "version": "26.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pretty-format/-/pretty-format-26.6.2.tgz",
+      "integrity": "sha1-41wnBfFMt/4v6U+geDRbREEg/JM=",
+      "requires": {
+        "@jest/types": "^26.6.2",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^4.0.0",
+        "react-is": "^17.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        }
+      }
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
+    },
+    "promise": {
+      "version": "8.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/promise/-/promise-8.1.0.tgz",
+      "integrity": "sha1-aXwlw9/nQ13Xn81Yw4oTWIjq8F4=",
+      "requires": {
+        "asap": "~2.0.6"
+      }
+    },
+    "promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+    },
+    "prompts": {
+      "version": "2.4.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/prompts/-/prompts-2.4.0.tgz",
+      "integrity": "sha1-SqXeByOiMdHukSHED99mPfc/Ydc=",
+      "requires": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha1-UsQedbjIfnK52TYOAga5ncv/psU=",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha1-eJcppNw23imZ3BVt1sHZwYzqVqQ=",
+          "dev": true
+        }
+      }
+    },
+    "proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha1-8Z/mnOqzEe65S0LnDowgcPm6ECU=",
+      "requires": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      }
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ="
+    },
+    "public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=",
+      "requires": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha1-d1s/J477uXGO7HNh9IP7Nvu/6og="
+        }
+      }
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "pumpify": {
+      "version": "1.5.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
+      "requires": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
+    },
+    "query-string": {
+      "version": "4.3.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/query-string/-/query-string-4.3.4.tgz",
+      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "requires": {
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
+    },
+    "querystring": {
+      "version": "0.2.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha1-QNd2FbsJ0WkCqFw+OKqLXtdhwt0="
+    },
+    "querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
+    },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha1-M0WUG0FTy50ILY7uTNogFqmu9/Y="
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM="
+    },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha1-B0LpmkplUvRF1z4+4DKK8P8e3jk=",
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
+      "requires": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha1-PPNwI9GZ4cJNGlW4SADC8+ZGgDE="
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha1-oc5vucm8NWylLoklarWQWeE9AzI=",
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/bytes/-/bytes-3.1.0.tgz",
+          "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY="
+        }
+      }
+    },
+    "react": {
+      "version": "16.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react/-/react-16.2.0.tgz",
+      "integrity": "sha1-oxvS2rib/2XUITT6GH8k0FTCc7o=",
+      "dev": true,
+      "requires": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
+      }
+    },
+    "react-app-polyfill": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-app-polyfill/-/react-app-polyfill-2.0.0.tgz",
+      "integrity": "sha1-oL6lDweLiggpcKnYU9w0ttzGo88=",
+      "requires": {
+        "core-js": "^3.6.5",
+        "object-assign": "^4.1.1",
+        "promise": "^8.1.0",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "react-dev-utils": {
+      "version": "11.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-dev-utils/-/react-dev-utils-11.0.4.tgz",
+      "integrity": "sha1-p8y2Alehyi4O/nqD445nANF6o3o=",
+      "requires": {
+        "@babel/code-frame": "7.10.4",
+        "address": "1.1.2",
+        "browserslist": "4.14.2",
+        "chalk": "2.4.2",
+        "cross-spawn": "7.0.3",
+        "detect-port-alt": "1.1.6",
+        "escape-string-regexp": "2.0.0",
+        "filesize": "6.1.0",
+        "find-up": "4.1.0",
+        "fork-ts-checker-webpack-plugin": "4.1.6",
+        "global-modules": "2.0.0",
+        "globby": "11.0.1",
+        "gzip-size": "5.1.1",
+        "immer": "8.0.1",
+        "is-root": "2.1.0",
+        "loader-utils": "2.0.0",
+        "open": "^7.0.2",
+        "pkg-up": "3.1.0",
+        "prompts": "2.4.0",
+        "react-error-overlay": "^6.0.9",
+        "recursive-readdir": "2.2.2",
+        "shell-quote": "1.7.2",
+        "strip-ansi": "6.0.0",
+        "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha1-Fo2ho26Q2miujUnA8bSMfGJJITo=",
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ="
+        },
+        "browserslist": {
+          "version": "4.14.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/browserslist/-/browserslist-4.14.2.tgz",
+          "integrity": "sha1-GzzsRYobqHWIzF6b5i8ZttSIE84=",
+          "requires": {
+            "caniuse-lite": "^1.0.30001125",
+            "electron-to-chromium": "^1.3.564",
+            "escalade": "^3.0.2",
+            "node-releases": "^1.1.61"
+          }
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha1-owME6Z2qMuI7L9IPUbq9B8/8o0Q="
+        },
+        "globby": {
+          "version": "11.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/globby/-/globby-11.0.1.tgz",
+          "integrity": "sha1-mivxB6Bo8//qvEmtcCx57ejP01c=",
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "node-releases": {
+          "version": "1.1.77",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/node-releases/-/node-releases-1.1.77.tgz",
+          "integrity": "sha1-ULDP7ehV3TdOdYW/Io/zTlfBwy4="
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U="
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI="
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/which/-/which-2.0.2.tgz",
+          "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "react-dom": {
+      "version": "16.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-dom/-/react-dom-16.2.0.tgz",
+      "integrity": "sha1-aQAxeGAcDKGbcJszqDNp/mEkwEQ=",
+      "dev": true,
+      "requires": {
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.0"
+      }
+    },
+    "react-error-overlay": {
+      "version": "6.0.9",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha1-PHQwEMk1lgjDdezWvHbzXZOZWwo="
+    },
+    "react-is": {
+      "version": "17.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha1-5pHUqOnHiTZWVVOas3J2Kw77VPA="
+    },
+    "react-refresh": {
+      "version": "0.8.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/react-refresh/-/react-refresh-0.8.3.tgz",
+      "integrity": "sha1-ch1GV2ctQAxePHXQY8SoX7LV1o8="
+    },
+    "read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha1-e/KVQ4yloz5WzTDgU7NO5yUMk8w=",
+      "requires": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha1-jSojcNPfiG61yQraHFv2GIrPg4s="
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha1-86YTV1hFlzOuK5VjgFbhhU5+9Qc=",
+      "requires": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha1-dKNwvYVxFuJFspzJc0DNQxoCpsc=",
+      "optional": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
+    "recursive-readdir": {
+      "version": "2.2.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
+      "integrity": "sha1-mUb7MnThYo3m42svZxSVO0hFCU8=",
+      "requires": {
+        "minimatch": "3.0.4"
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "requires": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      }
+    },
+    "regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha1-uTRtiCfo9aMve6KWN9OYtpAUhIo="
+    },
+    "regenerate-unicode-properties": {
+      "version": "9.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/regenerate-unicode-properties/-/regenerate-unicode-properties-9.0.0.tgz",
+      "integrity": "sha1-VNCccRXh9T3CMUqXSzLBw0Tv4yY=",
+      "requires": {
+        "regenerate": "^1.4.2"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha1-iSV0Kpj/2QgUmI11Zq0wyjsmO1I="
+    },
+    "regenerator-transform": {
+      "version": "0.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+      "integrity": "sha1-yY2hVGg2ccnE3LFuznNlF+G3/rQ=",
+      "requires": {
+        "@babel/runtime": "^7.8.4"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "regex-parser": {
+      "version": "2.2.11",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/regex-parser/-/regex-parser-2.2.11.tgz",
+      "integrity": "sha1-OzfskEnhlHmAboeMq+fByoPM/lg="
+    },
+    "regexp.prototype.flags": {
+      "version": "1.3.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+      "integrity": "sha1-fvNSro0VnnWMDq3Kb4/LTu8HviY=",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "regexpu-core": {
+      "version": "4.8.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/regexpu-core/-/regexpu-core-4.8.0.tgz",
+      "integrity": "sha1-5WBbo2G2excYR4UBMnUC9EeamPA=",
+      "requires": {
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^9.0.0",
+        "regjsgen": "^0.5.2",
+        "regjsparser": "^0.7.0",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.0.0"
+      }
+    },
+    "regjsgen": {
+      "version": "0.5.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/regjsgen/-/regjsgen-0.5.2.tgz",
+      "integrity": "sha1-kv8pX7He7L9uzaslQ9IH6RqjNzM="
+    },
+    "regjsparser": {
+      "version": "0.7.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/regjsparser/-/regjsparser-0.7.0.tgz",
+      "integrity": "sha1-prZntUyIXhi1JVTLSWDvcRh+mWg=",
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+        }
+      }
+    },
+    "relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+    },
+    "renderkid": {
+      "version": "2.0.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/renderkid/-/renderkid-2.0.7.tgz",
+      "integrity": "sha1-Rk8namvc7mBvShWZP5sp/HTKhgk=",
+      "requires": {
+        "css-select": "^4.1.3",
+        "dom-converter": "^0.2.0",
+        "htmlparser2": "^6.1.0",
+        "lodash": "^4.17.21",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "css-select": {
+          "version": "4.1.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/css-select/-/css-select-4.1.3.tgz",
+          "integrity": "sha1-pwRA9wMX8maRGK10/xBeZYSccGc=",
+          "requires": {
+            "boolbase": "^1.0.0",
+            "css-what": "^5.0.0",
+            "domhandler": "^4.2.0",
+            "domutils": "^2.6.0",
+            "nth-check": "^2.0.0"
+          }
+        },
+        "css-what": {
+          "version": "5.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/css-what/-/css-what-5.1.0.tgz",
+          "integrity": "sha1-P3tweq32M7r2LCzrhXm1RbtA9/4="
+        },
+        "dom-serializer": {
+          "version": "1.3.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/dom-serializer/-/dom-serializer-1.3.2.tgz",
+          "integrity": "sha1-YgZDfTLO767HFhgDIwx6ILwbTZE=",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domelementtype": {
+          "version": "2.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha1-mgtsJ4LtahxzI9QiZxg9+b2LHVc="
+        },
+        "domutils": {
+          "version": "2.8.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/domutils/-/domutils-2.8.0.tgz",
+          "integrity": "sha1-RDfe9dtuLR9dbuhZvZXKfQIEgTU=",
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.2.0",
+            "domhandler": "^4.2.0"
+          }
+        },
+        "nth-check": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/nth-check/-/nth-check-2.0.1.tgz",
+          "integrity": "sha1-Lv4WL1w9oGoolZ+9PbddvuqfD8I=",
+          "requires": {
+            "boolbase": "^1.0.0"
+          }
+        }
+      }
+    },
+    "repeat-element": {
+      "version": "1.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/repeat-element/-/repeat-element-1.1.4.tgz",
+      "integrity": "sha1-vmgVIIR6tYx1aKx1+/rSjtQtOek="
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/request/-/request-2.88.2.tgz",
+      "integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
+        }
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs="
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "resolve": {
+      "version": "1.18.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/resolve/-/resolve-1.18.1.tgz",
+      "integrity": "sha1-AY/LLFsgfSpkJK7jYcWiZtqPQTA=",
+      "requires": {
+        "is-core-module": "^2.0.0",
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha1-DwB18bslRHZs9zumpuKt/ryxPy0=",
+      "requires": {
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha1-w1IlhD3493bfIcV1V7wIfp39/Gk="
+        }
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY="
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+    },
+    "resolve-url-loader": {
+      "version": "3.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/resolve-url-loader/-/resolve-url-loader-3.1.4.tgz",
+      "integrity": "sha1-PBbK6+C5+uqcfMJS+knSNTxBIyA=",
+      "requires": {
+        "adjust-sourcemap-loader": "3.0.0",
+        "camelcase": "5.3.1",
+        "compose-function": "3.0.3",
+        "convert-source-map": "1.7.0",
+        "es6-iterator": "2.0.3",
+        "loader-utils": "1.2.3",
+        "postcss": "7.0.36",
+        "rework": "1.0.1",
+        "rework-visit": "1.0.0",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
+        },
+        "convert-source-map": {
+          "version": "1.7.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/convert-source-map/-/convert-source-map-1.7.0.tgz",
+          "integrity": "sha1-F6LLiC1/d9NJBYXizmxSRCSjpEI=",
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
+        },
+        "emojis-list": {
+          "version": "2.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/emojis-list/-/emojis-list-2.1.0.tgz",
+          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+        },
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.2.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/loader-utils/-/loader-utils-1.2.3.tgz",
+          "integrity": "sha1-H/XcaRHJ8KBiUxpMBLYJQGEIwsc=",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^2.0.0",
+            "json5": "^1.0.1"
+          }
+        },
+        "postcss": {
+          "version": "7.0.36",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss/-/postcss-7.0.36.tgz",
+          "integrity": "sha1-BW+M/6k5ZiqPWQWVDAfVKFZE38s=",
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w="
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY="
+    },
+    "rework": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/rework/-/rework-1.0.1.tgz",
+      "integrity": "sha1-MIBqhBNCtUUQqkEQhQzUhTQUSqc=",
+      "requires": {
+        "convert-source-map": "^0.3.3",
+        "css": "^2.0.0"
+      },
+      "dependencies": {
+        "convert-source-map": {
+          "version": "0.3.5",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/convert-source-map/-/convert-source-map-0.3.5.tgz",
+          "integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA="
+        }
+      }
+    },
+    "rework-visit": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/rework-visit/-/rework-visit-1.0.0.tgz",
+      "integrity": "sha1-mUWygD8hni96ygCtuLyfZA+ELJo="
+    },
+    "rgb-regex": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/rgb-regex/-/rgb-regex-1.0.1.tgz",
+      "integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE="
+    },
+    "rgba-regex": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/rgba-regex/-/rgba-regex-1.0.0.tgz",
+      "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
+    "rollup": {
+      "version": "1.32.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/rollup/-/rollup-1.32.1.tgz",
+      "integrity": "sha1-RIDlLZ2eKuS0a6DZ3erzFjlA+cQ=",
+      "requires": {
+        "@types/estree": "*",
+        "@types/node": "*",
+        "acorn": "^7.1.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo="
+        }
+      }
+    },
+    "rollup-plugin-babel": {
+      "version": "4.4.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/rollup-plugin-babel/-/rollup-plugin-babel-4.4.0.tgz",
+      "integrity": "sha1-0VvSWUZqnRrMvbL+L/8XxS0DCss=",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "rollup-plugin-terser": {
+      "version": "5.3.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/rollup-plugin-terser/-/rollup-plugin-terser-5.3.1.tgz",
+      "integrity": "sha1-jGUAYsIqhCbGQmhUiVdGO/mBtBM=",
+      "requires": {
+        "@babel/code-frame": "^7.5.5",
+        "jest-worker": "^24.9.0",
+        "rollup-pluginutils": "^2.8.2",
+        "serialize-javascript": "^4.0.0",
+        "terser": "^4.6.2"
+      },
+      "dependencies": {
+        "jest-worker": {
+          "version": "24.9.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jest-worker/-/jest-worker-24.9.0.tgz",
+          "integrity": "sha1-Xb/bWy0yLphWeJgjipaXvM5ns+U=",
+          "requires": {
+            "merge-stream": "^2.0.0",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "serialize-javascript": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+          "integrity": "sha1-tSXhI4SJpez8Qq+sw/6Z5mb0sao=",
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha1-cvKvB0i1kjZNvTOJ5gDlqURKNR4=",
+      "requires": {
+        "estree-walker": "^0.6.1"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/estree-walker/-/estree-walker-0.6.1.tgz",
+          "integrity": "sha1-UwSRQ/QMbrkYsjZx0f4yGfOhs2I="
+        }
+      }
+    },
+    "rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha1-yPFVMR0Wf2jyHhaN9x7FsIMRNzQ="
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "run-queue": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/run-queue/-/run-queue-1.0.3.tgz",
+      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+      "requires": {
+        "aproba": "^1.1.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
+    },
+    "sane": {
+      "version": "4.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/sane/-/sane-4.1.0.tgz",
+      "integrity": "sha1-7Ygf2SJzOmxGG8GJ3CtsAG8//e0=",
+      "requires": {
+        "@cnakazawa/watch": "^1.0.3",
+        "anymatch": "^2.0.0",
+        "capture-exit": "^2.0.0",
+        "exec-sh": "^0.3.2",
+        "execa": "^1.0.0",
+        "fb-watchman": "^2.0.0",
+        "micromatch": "^3.1.4",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          }
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
+    "sanitize.css": {
+      "version": "10.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/sanitize.css/-/sanitize.css-10.0.0.tgz",
+      "integrity": "sha1-tcslR+lthimmCUdURmUkOx3DZXo="
+    },
+    "sass-graph": {
+      "version": "2.2.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/sass-graph/-/sass-graph-2.2.5.tgz",
+      "integrity": "sha1-qYHIdEa4MZ2W3OBnHkh4eb0kwug=",
+      "requires": {
+        "glob": "^7.0.0",
+        "lodash": "^4.0.0",
+        "scss-tokenizer": "^0.2.3",
+        "yargs": "^13.3.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY="
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha1-Ew8JcC667vJlDVTObj5XBvek+zg=",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "sass-loader": {
+      "version": "7.3.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/sass-loader/-/sass-loader-7.3.1.tgz",
+      "integrity": "sha1-pb9ooEvOocE/+ELXRxUPerfQ0j8=",
+      "requires": {
+        "clone-deep": "^4.0.1",
+        "loader-utils": "^1.0.1",
+        "neo-async": "^2.5.0",
+        "pify": "^4.0.1",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
+        }
+      }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
+    },
+    "saxes": {
+      "version": "5.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha1-7rq5U/o7dgjb6U5drbFciI+maW0=",
+      "requires": {
+        "xmlchars": "^2.2.0"
+      }
+    },
+    "schema-utils": {
+      "version": "2.7.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/schema-utils/-/schema-utils-2.7.1.tgz",
+      "integrity": "sha1-HKTzLRskxZDCA7jnpQvw6kzTlNc=",
+      "requires": {
+        "@types/json-schema": "^7.0.5",
+        "ajv": "^6.12.4",
+        "ajv-keywords": "^3.5.2"
+      }
+    },
+    "scss-tokenizer": {
+      "version": "0.2.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+      "requires": {
+        "js-base64": "^2.1.8",
+        "source-map": "^0.4.2"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
+    },
+    "select-hose": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/select-hose/-/select-hose-2.0.0.tgz",
+      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
+    },
+    "selfsigned": {
+      "version": "1.10.11",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/selfsigned/-/selfsigned-1.10.11.tgz",
+      "integrity": "sha1-JJKc2Qb+D0S20B+yOZmnOVN6y+k=",
+      "requires": {
+        "node-forge": "^0.10.0"
+      }
+    },
+    "semver": {
+      "version": "7.3.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha1-YElisFK4HtB4aq6EOJ/7pw/9OTg="
+    },
+    "send": {
+      "version": "0.17.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/send/-/send-0.17.1.tgz",
+      "integrity": "sha1-wdiwWfeQD3Rm3Uk4vcROEd2zdsg=",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo="
+        }
+      }
+    },
+    "serialize-javascript": {
+      "version": "5.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+      "integrity": "sha1-eIbshIBJpGJGepfT2Rjrsqr5NPQ=",
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "serve-index": {
+      "version": "1.9.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/serve-index/-/serve-index-1.9.1.tgz",
+      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+      "requires": {
+        "accepts": "~1.3.4",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "http-errors": {
+          "version": "1.6.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/http-errors/-/http-errors-1.6.3.tgz",
+          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha1-Zm5jbcTwEPfvKZcKiKZ0MgiYsvk=",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "set-value": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM="
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha1-jymBrZJTH1UDWwH7IwdppA4C76M=",
+      "requires": {
+        "kind-of": "^6.0.2"
+      }
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "shell-quote": {
+      "version": "1.7.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/shell-quote/-/shell-quote-1.7.2.tgz",
+      "integrity": "sha1-Z6fQLHbJ2iT5nSCAj8re0ODgS+I="
+    },
+    "shellwords": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha1-1rkYHBpI05cyTISHHvvPxz/AZUs=",
+      "optional": true
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha1-785cj9wQTudRslxY1CkAEfpeos8=",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
+    "signal-exit": {
+      "version": "3.0.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/signal-exit/-/signal-exit-3.0.5.tgz",
+      "integrity": "sha1-nj6MwMdamUcrRDIQM6dwLnc4JS8="
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha1-RXSirlb3qyBolvtDHq7tBm/fjwM="
+        }
+      }
+    },
+    "sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha1-E01oEpd1ZDfMBcoBNw06elcQde0="
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ="
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "sockjs": {
+      "version": "0.3.21",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/sockjs/-/sockjs-0.3.21.tgz",
+      "integrity": "sha1-s0/7mOeWkwtgoM+hGQTWozmn1Bc=",
+      "requires": {
+        "faye-websocket": "^0.11.3",
+        "uuid": "^3.4.0",
+        "websocket-driver": "^0.7.4"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
+        }
+      }
+    },
+    "sockjs-client": {
+      "version": "1.5.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/sockjs-client/-/sockjs-client-1.5.2.tgz",
+      "integrity": "sha1-S8SMLanOR2nxnccjOWtQ9cEjMKM=",
+      "requires": {
+        "debug": "^3.2.6",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "^0.11.3",
+        "inherits": "^2.0.4",
+        "json3": "^3.3.3",
+        "url-parse": "^1.5.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
+    },
+    "source-list-map": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-list-map/-/source-list-map-2.0.1.tgz",
+      "integrity": "sha1-OZO9hzv8SEecyp6jpUeDXHwVSzQ="
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "source-map-js": {
+      "version": "0.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map-js/-/source-map-js-0.6.2.tgz",
+      "integrity": "sha1-C7XeYxtBz72mz7qL0FqA79/SOF4="
+    },
+    "source-map-resolve": {
+      "version": "0.5.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha1-GQhmvs51U+H48mei7oLGBrVQmho=",
+      "requires": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-support": {
+      "version": "0.5.20",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map-support/-/source-map-support-0.5.20.tgz",
+      "integrity": "sha1-EhZgifj15ejFaSazd2Mzkt0stsk=",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        }
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map-url/-/source-map-url-0.4.1.tgz",
+      "integrity": "sha1-CvZmBadFpaL5HPG7+KevvCg97FY="
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha1-6oBL2UhXQC5pktBaOO8a41qatMQ="
+    },
+    "spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha1-3s6BrJweZxPl99G28X1Gj6U9iak=",
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha1-PyjOGnegA3JoPq3kpDMYNSeiFj0="
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha1-z3D1BILu/cmOPOCmgz5KU87rpnk=",
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.10",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz",
+      "integrity": "sha1-DZvszN5wA9bGWNSH3UijLwvzAUs="
+    },
+    "spdy": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/spdy/-/spdy-4.0.2.tgz",
+      "integrity": "sha1-t09GYgOj7aRSwCSSuR+56EonZ3s=",
+      "requires": {
+        "debug": "^4.1.0",
+        "handle-thing": "^2.0.0",
+        "http-deceiver": "^1.2.7",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^3.0.0"
+      }
+    },
+    "spdy-transport": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/spdy-transport/-/spdy-transport-3.0.0.tgz",
+      "integrity": "sha1-ANSGOmQArXXfkzYaFghgXl3NzzE=",
+      "requires": {
+        "debug": "^4.1.0",
+        "detect-node": "^2.0.4",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.2",
+        "readable-stream": "^3.0.6",
+        "wbuf": "^1.7.3"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "ssri": {
+      "version": "8.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha1-Y45OQ54v+9LNKJd21cpFfE9Roq8=",
+      "requires": {
+        "minipass": "^3.1.1"
+      }
+    },
+    "stable": {
+      "version": "0.1.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/stable/-/stable-0.1.8.tgz",
+      "integrity": "sha1-g26zyDgv4pNv6vVEYxAXzn1Ho88="
+    },
+    "stack-utils": {
+      "version": "2.0.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/stack-utils/-/stack-utils-2.0.5.tgz",
+      "integrity": "sha1-0lJl/KmVFUZZ27+6O0klR3jS/dU=",
+      "requires": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha1-owME6Z2qMuI7L9IPUbq9B8/8o0Q="
+        }
+      }
+    },
+    "stackframe": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/stackframe/-/stackframe-1.2.0.tgz",
+      "integrity": "sha1-UkKUktY8YuuYmATBFVLj0i53kwM="
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "stdout-stream": {
+      "version": "1.4.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/stdout-stream/-/stdout-stream-1.4.1.tgz",
+      "integrity": "sha1-WsF0zdXNcmEEqgwLK9g4FdjVNd4=",
+      "requires": {
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "stream-browserify": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "integrity": "sha1-h1IdOKRKp+6RzhzSpH3wy0ndZgs=",
+      "requires": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "stream-each": {
+      "version": "1.2.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/stream-each/-/stream-each-1.2.3.tgz",
+      "integrity": "sha1-6+J6DDibBPvMIzZClS4Qcxr6m64=",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "stream-http": {
+      "version": "2.8.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/stream-http/-/stream-http-2.8.3.tgz",
+      "integrity": "sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=",
+      "requires": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha1-1wiCgVWasneEJCebCHfaPDktWj0="
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+    },
+    "string-length": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha1-qKjce9XBqCubPIuH4SX2aHG25Xo=",
+      "requires": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ="
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ="
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha1-51rpDClCxjUEaGwYsoe0oLGkX4A=",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha1-s2OZr0qymZtMnGSL16P7K7Jv7u0=",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha1-cDBlrvyhkwDTzoivT1s5VtdVZik=",
+      "requires": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
+      },
+      "dependencies": {
+        "is-obj": {
+          "version": "1.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-obj/-/is-obj-1.0.1.tgz",
+          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+        }
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha1-nDUFwdtFvO3KPZz3oW9cWqOQGHg="
+    },
+    "strip-comments": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strip-comments/-/strip-comments-1.0.2.tgz",
+      "integrity": "sha1-grnEXn8FhzvuU/NxaK+TCqNoZ50=",
+      "requires": {
+        "babel-extract-comments": "^1.0.0",
+        "babel-plugin-transform-object-rest-spread": "^6.26.0"
+      }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0="
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "requires": {
+        "get-stdin": "^4.0.1"
+      }
+    },
+    "style-loader": {
+      "version": "1.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/style-loader/-/style-loader-1.3.0.tgz",
+      "integrity": "sha1-gotKOzt+eqWEfOe66eh0USEUJJ4=",
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^2.7.0"
+      }
+    },
+    "stylehacks": {
+      "version": "4.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/stylehacks/-/stylehacks-4.0.3.tgz",
+      "integrity": "sha1-Zxj8r00eB9ihMYaQiB6NlnJqcdU=",
+      "requires": {
+        "browserslist": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-selector-parser": {
+          "version": "3.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+          "integrity": "sha1-sxD1xMD9r3b5SQK7qjDbaqhPUnA=",
+          "requires": {
+            "dot-prop": "^5.2.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "supports-hyperlinks": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+      "integrity": "sha1-T3e0JIh2WJF3S3DHm6vYf5vVlLs=",
+      "requires": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "svg-parser": {
+      "version": "2.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/svg-parser/-/svg-parser-2.0.4.tgz",
+      "integrity": "sha1-/cLinhOVFzYUC3bLEiyO5mMOtrU="
+    },
+    "svgo": {
+      "version": "1.3.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/svgo/-/svgo-1.3.2.tgz",
+      "integrity": "sha1-ttxRHAYzRsnkFbgeQ0ARRbltQWc=",
+      "requires": {
+        "chalk": "^2.4.1",
+        "coa": "^2.0.2",
+        "css-select": "^2.0.0",
+        "css-select-base-adapter": "^0.1.1",
+        "css-tree": "1.0.0-alpha.37",
+        "csso": "^4.0.2",
+        "js-yaml": "^3.13.1",
+        "mkdirp": "~0.5.1",
+        "object.values": "^1.1.0",
+        "sax": "~1.2.4",
+        "stable": "^0.1.8",
+        "unquote": "~1.1.1",
+        "util.promisify": "~1.0.0"
+      }
+    },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha1-QwY30ki6d+B4iDlR+5qg7tfGP6I="
+    },
+    "tapable": {
+      "version": "1.1.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tapable/-/tapable-1.1.3.tgz",
+      "integrity": "sha1-ofzMBrWNth/XpF2i2kT186Pme6I="
+    },
+    "tar": {
+      "version": "2.2.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha1-DKiEhWLHKZuLRG/2pNYM27I+3EA=",
+      "requires": {
+        "block-stream": "*",
+        "fstream": "^1.0.12",
+        "inherits": "2"
+      }
+    },
+    "temp-dir": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/temp-dir/-/temp-dir-1.0.0.tgz",
+      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
+    },
+    "tempy": {
+      "version": "0.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tempy/-/tempy-0.3.0.tgz",
+      "integrity": "sha1-b2xbKVaVoWEwmWrVqwGovXJui/g=",
+      "requires": {
+        "temp-dir": "^1.0.0",
+        "type-fest": "^0.3.1",
+        "unique-string": "^1.0.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/type-fest/-/type-fest-0.3.1.tgz",
+          "integrity": "sha1-Y9ANIE4FlHT+Xht8ARESu9HcKeE="
+        }
+      }
+    },
+    "terminal-link": {
+      "version": "2.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/terminal-link/-/terminal-link-2.1.1.tgz",
+      "integrity": "sha1-FKZKJ6s8Dfkz6lRvulXy0HjtyZQ=",
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "supports-hyperlinks": "^2.0.0"
+      }
+    },
+    "terser": {
+      "version": "4.8.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/terser/-/terser-4.8.0.tgz",
+      "integrity": "sha1-YwVjQ9fHC7KfOvZlhlpG/gOg3xc=",
+      "requires": {
+        "commander": "^2.20.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.12"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        }
+      }
+    },
+    "terser-webpack-plugin": {
+      "version": "4.2.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/terser-webpack-plugin/-/terser-webpack-plugin-4.2.3.tgz",
+      "integrity": "sha1-KNrvSoO9F8HbApcHCtwH/Iz8apo=",
+      "requires": {
+        "cacache": "^15.0.5",
+        "find-cache-dir": "^3.3.1",
+        "jest-worker": "^26.5.0",
+        "p-limit": "^3.0.2",
+        "schema-utils": "^3.0.0",
+        "serialize-javascript": "^5.0.1",
+        "source-map": "^0.6.1",
+        "terser": "^5.3.4",
+        "webpack-sources": "^1.4.3"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM="
+        },
+        "find-cache-dir": {
+          "version": "3.3.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+          "integrity": "sha1-swxbbv8HMHMa6pu9nb7L2AJW1ks=",
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^3.0.2",
+            "pkg-dir": "^4.1.0"
+          }
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha1-QV6WcEazp/HRhSd9hKpYIDcmoT8=",
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "schema-utils": {
+          "version": "3.1.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/schema-utils/-/schema-utils-3.1.1.tgz",
+          "integrity": "sha1-vHTEtraZXB2I92qLd76nIZ4MgoE=",
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        },
+        "terser": {
+          "version": "5.9.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/terser/-/terser-5.9.0.tgz",
+          "integrity": "sha1-R9bmKaUiljJA8rVfyqPJkIPSw1E=",
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.7.2",
+            "source-map-support": "~0.5.20"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.7.3",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.7.3.tgz",
+              "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M="
+            }
+          }
+        }
+      }
+    },
+    "test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha1-BKhphmHYBepvopO2y55jrARO8V4=",
+      "requires": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+    },
+    "thread-loader": {
+      "version": "3.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/thread-loader/-/thread-loader-3.0.4.tgz",
+      "integrity": "sha1-w5LkwCQfvIBDDraA5IhoGbUEoxs=",
+      "requires": {
+        "json-parse-better-errors": "^1.0.2",
+        "loader-runner": "^4.1.0",
+        "loader-utils": "^2.0.0",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "3.1.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/schema-utils/-/schema-utils-3.1.1.tgz",
+          "integrity": "sha1-vHTEtraZXB2I92qLd76nIZ4MgoE=",
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
+    "throat": {
+      "version": "5.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/throat/-/throat-5.0.0.tgz",
+      "integrity": "sha1-xRmSNYA6rRh1SmZ9ZZtecs4Wdks="
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "thunky": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha1-Wrr3FKlAXbBQRzK7zNLO3Z75U30="
+    },
+    "timers-browserify": {
+      "version": "2.0.12",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/timers-browserify/-/timers-browserify-2.0.12.tgz",
+      "integrity": "sha1-RKRcEfv0B/NPl7zNFXfGUjYbAO4=",
+      "requires": {
+        "setimmediate": "^1.0.4"
+      }
+    },
+    "timsort": {
+      "version": "0.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/timsort/-/timsort-0.3.0.tgz",
+      "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
+    },
+    "tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha1-hoPguQK7nCDE9ybjwLafNlGMB8w="
+    },
+    "to-arraybuffer": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM="
+    },
+    "tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha1-2CIjTuyogvmR8PkIgkrSYi3b7OQ=",
+      "requires": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.1.2"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY="
+        }
+      }
+    },
+    "tr46": {
+      "version": "2.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha1-+oeqgcpdWUHajL8fm3SdyWmk4kA=",
+      "requires": {
+        "punycode": "^2.1.1"
+      }
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+    },
+    "true-case-path": {
+      "version": "1.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/true-case-path/-/true-case-path-1.0.3.tgz",
+      "integrity": "sha1-+BO1qMhrQNpZYGcisUTjIleZ9H0=",
+      "requires": {
+        "glob": "^7.1.2"
+      }
+    },
+    "tryer": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tryer/-/tryer-1.0.1.tgz",
+      "integrity": "sha1-8shUBoALmw90yfdGW4HqrSQSUvg="
+    },
+    "ts-pnp": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ts-pnp/-/ts-pnp-1.2.0.tgz",
+      "integrity": "sha1-pQCtCEsHmPHDBxrzkeZZEshrypI="
+    },
+    "tty-browserify": {
+      "version": "0.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/type/-/type-1.2.0.tgz",
+      "integrity": "sha1-hI3XaY2vo+VKbEeedZxLw/GIR6A="
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw="
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha1-CeJJ696FHTseSNJ8EFREZn8XuD0="
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha1-TlUs0F3wlGfcvE73Od6J8s83wTE=",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha1-qX7nqf9CaRufeD/xvFES/j/KkIA=",
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "ua-parser-js": {
+      "version": "0.7.28",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+      "integrity": "sha1-i6BOZT81ziECOcZGYWhb+RId7DE=",
+      "dev": true
+    },
+    "unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha1-CF4hViXsMWJXTciFmr7nilmxRHE=",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      }
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
+      "integrity": "sha1-MBrNxSVjFnDTn2FG4Od/9rvevdw="
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha1-VP0W4OyxZ88Ezx91a9zJLrp5dsM=",
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.0.0.tgz",
+      "integrity": "sha1-GgGqVyR8FMVouJd1pUk4eIGJpxQ="
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz",
+      "integrity": "sha1-CjbLmlhcT2q9Ua0d7dsoXBZSl8g="
+    },
+    "union-value": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      }
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+    },
+    "uniqs": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/uniqs/-/uniqs-2.0.0.tgz",
+      "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
+    },
+    "unique-filename": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha1-HWl2k2mtoFgxA6HmrodoG1ZXMjA=",
+      "requires": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "unique-slug": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha1-uqvOkQg/xk6UWw861hPiZPfNTmw=",
+      "requires": {
+        "imurmurhash": "^0.1.4"
+      }
+    },
+    "unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "requires": {
+        "crypto-random-string": "^1.0.0"
+      }
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha1-daSYTv7cSwiXXFrrc/Uw0C3yVxc="
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "unquote": {
+      "version": "1.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/unquote/-/unquote-1.1.1.tgz",
+      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+        }
+      }
+    },
+    "upath": {
+      "version": "1.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha1-j2bbzVWog6za5ECK+LA1pQRMGJQ="
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "querystring": {
+          "version": "0.2.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/querystring/-/querystring-0.2.0.tgz",
+          "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+        }
+      }
+    },
+    "url-loader": {
+      "version": "4.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/url-loader/-/url-loader-4.1.1.tgz",
+      "integrity": "sha1-KFBekFyuFYzwfJLKYi1/I35wpOI=",
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "mime-types": "^2.1.27",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "3.1.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/schema-utils/-/schema-utils-3.1.1.tgz",
+          "integrity": "sha1-vHTEtraZXB2I92qLd76nIZ4MgoE=",
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
+    "url-parse": {
+      "version": "1.5.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha1-ccEwPTj7Zjmt4YPCmSyMwGht+GI=",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/use/-/use-3.1.1.tgz",
+      "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8="
+    },
+    "util": {
+      "version": "0.11.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/util/-/util-0.11.1.tgz",
+      "integrity": "sha1-MjZzNyDsZLsn9uJvQhqqLhtYjWE=",
+      "requires": {
+        "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "util.promisify": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/util.promisify/-/util.promisify-1.0.1.tgz",
+      "integrity": "sha1-a693dLgO6w91INi4HQeYKlmruu4=",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.2",
+        "has-symbols": "^1.0.1",
+        "object.getownpropertydescriptors": "^2.1.0"
+      }
+    },
+    "utila": {
+      "version": "0.4.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/utila/-/utila-0.4.0.tgz",
+      "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
+      "optional": true
+    },
+    "v8-to-istanbul": {
+      "version": "7.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/v8-to-istanbul/-/v8-to-istanbul-7.1.2.tgz",
+      "integrity": "sha1-MImNGn+gyE0iWiwUNPuVjykIg8E=",
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^1.6.0",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M="
+        }
+      }
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "vendors": {
+      "version": "1.0.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/vendors/-/vendors-1.0.4.tgz",
+      "integrity": "sha1-4rgApT56Kbk1BsPPQRANFsTErY4="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        }
+      }
+    },
+    "vm-browserify": {
+      "version": "1.1.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha1-eGQcSIuObKkadfUR56OzKobl3aA="
+    },
+    "w3c-hr-time": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha1-ConN9cwVgi35w2BUNnaWPgzDCM0=",
+      "requires": {
+        "browser-process-hrtime": "^1.0.0"
+      }
+    },
+    "w3c-xmlserializer": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+      "integrity": "sha1-PnEEoFt1FGzGD1ZDgLf2g6zxAgo=",
+      "requires": {
+        "xml-name-validator": "^3.0.0"
+      }
+    },
+    "walker": {
+      "version": "1.0.7",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/walker/-/walker-1.0.7.tgz",
+      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "requires": {
+        "makeerror": "1.0.x"
+      }
+    },
+    "watchpack": {
+      "version": "1.7.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/watchpack/-/watchpack-1.7.5.tgz",
+      "integrity": "sha1-EmfmxV4Lm1vkTCAjrtVDeiwmxFM=",
+      "requires": {
+        "chokidar": "^3.4.1",
+        "graceful-fs": "^4.1.2",
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.1"
+      }
+    },
+    "watchpack-chokidar2": {
+      "version": "2.0.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz",
+      "integrity": "sha1-OFAAcu5uzmbzdpk2lQ6hdxvhyVc=",
+      "optional": true,
+      "requires": {
+        "chokidar": "^2.1.8"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
+          "optional": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          },
+          "dependencies": {
+            "normalize-path": {
+              "version": "2.1.1",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/normalize-path/-/normalize-path-2.1.1.tgz",
+              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+              "optional": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
+          }
+        },
+        "binary-extensions": {
+          "version": "1.13.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U=",
+          "optional": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+          "optional": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "optional": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "chokidar": {
+          "version": "2.1.8",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chokidar/-/chokidar-2.1.8.tgz",
+          "integrity": "sha1-gEs6e2qZNYw8XGHnHYco8EHP+Rc=",
+          "optional": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "optional": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "optional": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=",
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "optional": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "optional": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+          "optional": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "optional": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "optional": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+          "optional": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "optional": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
+    "wbuf": {
+      "version": "1.7.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/wbuf/-/wbuf-1.7.3.tgz",
+      "integrity": "sha1-wdjRSTFtPqhShIiVy2oL/oh7h98=",
+      "requires": {
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha1-kRG01+qArNQPUnDWZmIa+ni2lRQ="
+    },
+    "webpack": {
+      "version": "4.44.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/webpack/-/webpack-4.44.2.tgz",
+      "integrity": "sha1-a/4rCvBVyLLR6Q7SzZNj+EEma3I=",
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-module-context": "1.9.0",
+        "@webassemblyjs/wasm-edit": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0",
+        "acorn": "^6.4.1",
+        "ajv": "^6.10.2",
+        "ajv-keywords": "^3.4.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^4.3.0",
+        "eslint-scope": "^4.0.3",
+        "json-parse-better-errors": "^1.0.2",
+        "loader-runner": "^2.4.0",
+        "loader-utils": "^1.2.3",
+        "memory-fs": "^0.4.1",
+        "micromatch": "^3.1.10",
+        "mkdirp": "^0.5.3",
+        "neo-async": "^2.6.1",
+        "node-libs-browser": "^2.2.1",
+        "schema-utils": "^1.0.0",
+        "tapable": "^1.1.3",
+        "terser-webpack-plugin": "^1.4.3",
+        "watchpack": "^1.7.4",
+        "webpack-sources": "^1.4.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.4.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/acorn/-/acorn-6.4.2.tgz",
+          "integrity": "sha1-NYZv1xBSjpLeEM8GAWSY5H454eY="
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "cacache": {
+          "version": "12.0.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cacache/-/cacache-12.0.4.tgz",
+          "integrity": "sha1-ZovL0QWutfHZL+JVcOyVJcj6pAw=",
+          "requires": {
+            "bluebird": "^3.5.5",
+            "chownr": "^1.1.1",
+            "figgy-pudding": "^3.5.1",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.1.15",
+            "infer-owner": "^1.0.3",
+            "lru-cache": "^5.1.1",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.3",
+            "ssri": "^6.0.1",
+            "unique-filename": "^1.1.1",
+            "y18n": "^4.0.0"
+          }
+        },
+        "chownr": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs="
+        },
+        "eslint-scope": {
+          "version": "4.0.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/eslint-scope/-/eslint-scope-4.0.3.tgz",
+          "integrity": "sha1-ygODMxD2iJoyZHgaqC5j65z+eEg=",
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-wsl": {
+          "version": "1.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-wsl/-/is-wsl-1.1.0.tgz",
+          "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+        },
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-runner": {
+          "version": "2.4.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/loader-runner/-/loader-runner-2.4.0.tgz",
+          "integrity": "sha1-7UcGa/5TTX6ExMe5mYwqdWB9k1c="
+        },
+        "loader-utils": {
+          "version": "1.4.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        },
+        "serialize-javascript": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+          "integrity": "sha1-tSXhI4SJpez8Qq+sw/6Z5mb0sao=",
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        },
+        "ssri": {
+          "version": "6.0.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ssri/-/ssri-6.0.2.tgz",
+          "integrity": "sha1-FXk5E08gRk5zAd26PpD/qPdyisU=",
+          "requires": {
+            "figgy-pudding": "^3.5.1"
+          }
+        },
+        "terser-webpack-plugin": {
+          "version": "1.4.5",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+          "integrity": "sha1-oheu+uozDnNP+sthIOwfoxLWBAs=",
+          "requires": {
+            "cacache": "^12.0.2",
+            "find-cache-dir": "^2.1.0",
+            "is-wsl": "^1.1.0",
+            "schema-utils": "^1.0.0",
+            "serialize-javascript": "^4.0.0",
+            "source-map": "^0.6.1",
+            "terser": "^4.1.2",
+            "webpack-sources": "^1.4.0",
+            "worker-farm": "^1.7.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0="
+        }
+      }
+    },
+    "webpack-dev-middleware": {
+      "version": "3.7.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/webpack-dev-middleware/-/webpack-dev-middleware-3.7.3.tgz",
+      "integrity": "sha1-Bjk3KxQyYuK4SrldO5GnWXBhwsU=",
+      "requires": {
+        "memory-fs": "^0.4.1",
+        "mime": "^2.4.4",
+        "mkdirp": "^0.5.1",
+        "range-parser": "^1.2.1",
+        "webpack-log": "^2.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.5.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/mime/-/mime-2.5.2.tgz",
+          "integrity": "sha1-bj3GzCuVEGQ4MOXxnVy3U9pe6r4="
+        }
+      }
+    },
+    "webpack-dev-server": {
+      "version": "3.11.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/webpack-dev-server/-/webpack-dev-server-3.11.1.tgz",
+      "integrity": "sha1-x0Aov1uoiFqvIw5Iog6JNquFEfA=",
+      "requires": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.3.1",
+        "http-proxy-middleware": "0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.3",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.8",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.26",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.8",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "^0.3.21",
+        "sockjs-client": "^1.5.0",
+        "spdy": "^4.0.2",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.2",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "^13.3.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
+        },
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          },
+          "dependencies": {
+            "normalize-path": {
+              "version": "2.1.1",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/normalize-path/-/normalize-path-2.1.1.tgz",
+              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
+          }
+        },
+        "binary-extensions": {
+          "version": "1.13.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U="
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
+        },
+        "chokidar": {
+          "version": "2.1.8",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/chokidar/-/chokidar-2.1.8.tgz",
+          "integrity": "sha1-gEs6e2qZNYw8XGHnHYco8EHP+Rc=",
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
+          }
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "5.2.0",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
+            }
+          }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY="
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=",
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "import-local": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/import-local/-/import-local-2.0.0.tgz",
+          "integrity": "sha1-VQcL44pZk88Y72236WH1vuXFoJ0=",
+          "requires": {
+            "pkg-dir": "^3.0.0",
+            "resolve-cwd": "^2.0.0"
+          }
+        },
+        "is-absolute-url": {
+          "version": "3.0.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
+          "integrity": "sha1-lsaiK2ojkpsR6gr7GDbDatSl1pg="
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "resolve-cwd": {
+          "version": "2.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+          "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+          "requires": {
+            "resolve-from": "^3.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "5.2.0",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
+            }
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "5.2.0",
+              "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
+            }
+          }
+        },
+        "ws": {
+          "version": "6.2.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ws/-/ws-6.2.2.tgz",
+          "integrity": "sha1-3Vzb1XqZeZFgl2UtePHMX66gwy4=",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha1-Ew8JcC667vJlDVTObj5XBvek+zg=",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "webpack-log": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/webpack-log/-/webpack-log-2.0.0.tgz",
+      "integrity": "sha1-W3ko4GN1k/EZ0y9iJ8HgrDHhtH8=",
+      "requires": {
+        "ansi-colors": "^3.0.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
+        }
+      }
+    },
+    "webpack-manifest-plugin": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/webpack-manifest-plugin/-/webpack-manifest-plugin-2.2.0.tgz",
+      "integrity": "sha1-GcpptDWwuux+KfvpD7QBXeLeTxY=",
+      "requires": {
+        "fs-extra": "^7.0.0",
+        "lodash": ">=3.5 <5",
+        "object.entries": "^1.1.0",
+        "tapable": "^1.0.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY="
+        }
+      }
+    },
+    "webpack-sources": {
+      "version": "1.4.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/webpack-sources/-/webpack-sources-1.4.3.tgz",
+      "integrity": "sha1-7t2OwLko+/HL/plOItLYkPMwqTM=",
+      "requires": {
+        "source-list-map": "^2.0.0",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        }
+      }
+    },
+    "webpack-subresource-integrity": {
+      "version": "1.5.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/webpack-subresource-integrity/-/webpack-subresource-integrity-1.5.2.tgz",
+      "integrity": "sha1-5AtleNMHLi0kEEl1JJxSxm6adD4=",
+      "requires": {
+        "webpack-sources": "^1.3.0"
+      }
+    },
+    "websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha1-ia1Slbv2S0gKvLox5JU6ynBvV2A=",
+      "requires": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha1-f4RzvIOd/YdgituV1+sHUhFXikI="
+    },
+    "whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha1-WrrPd3wyFmpR0IXWtPPn0nET3bA=",
+      "requires": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha1-3O0k838mJO0CgXJdUdDi4/5nf4w="
+    },
+    "whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha1-PUseAxLSB5h5+Cav8Y2+7KWWD78="
+    },
+    "whatwg-url": {
+      "version": "8.7.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/whatwg-url/-/whatwg-url-8.7.0.tgz",
+      "integrity": "sha1-ZWp45RD/jzk3vAvL6fXArDWUG3c=",
+      "requires": {
+        "lodash": "^4.7.0",
+        "tr46": "^2.1.0",
+        "webidl-conversions": "^6.1.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/which/-/which-1.3.1.tgz",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha1-E3V7yJsgmwSf5dhkMOIc9AqJqOY=",
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha1-3x1MIGhUNp7PPJpImPGyP72dFdM=",
+      "requires": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w="
+    },
+    "workbox-background-sync": {
+      "version": "5.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/workbox-background-sync/-/workbox-background-sync-5.1.4.tgz",
+      "integrity": "sha1-WuC71FX06cMZ6NgnwFW7hsiU/RI=",
+      "requires": {
+        "workbox-core": "^5.1.4"
+      }
+    },
+    "workbox-broadcast-update": {
+      "version": "5.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/workbox-broadcast-update/-/workbox-broadcast-update-5.1.4.tgz",
+      "integrity": "sha1-DuuJFw3cp/aRT6NSP7FEYokfLPw=",
+      "requires": {
+        "workbox-core": "^5.1.4"
+      }
+    },
+    "workbox-build": {
+      "version": "5.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/workbox-build/-/workbox-build-5.1.4.tgz",
+      "integrity": "sha1-I9F+1cMgYMNjAwyII7OdDqv0yMc=",
+      "requires": {
+        "@babel/core": "^7.8.4",
+        "@babel/preset-env": "^7.8.4",
+        "@babel/runtime": "^7.8.4",
+        "@hapi/joi": "^15.1.0",
+        "@rollup/plugin-node-resolve": "^7.1.1",
+        "@rollup/plugin-replace": "^2.3.1",
+        "@surma/rollup-plugin-off-main-thread": "^1.1.1",
+        "common-tags": "^1.8.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "fs-extra": "^8.1.0",
+        "glob": "^7.1.6",
+        "lodash.template": "^4.5.0",
+        "pretty-bytes": "^5.3.0",
+        "rollup": "^1.31.1",
+        "rollup-plugin-babel": "^4.3.3",
+        "rollup-plugin-terser": "^5.3.1",
+        "source-map": "^0.7.3",
+        "source-map-url": "^0.4.0",
+        "stringify-object": "^3.3.0",
+        "strip-comments": "^1.0.2",
+        "tempy": "^0.3.0",
+        "upath": "^1.2.0",
+        "workbox-background-sync": "^5.1.4",
+        "workbox-broadcast-update": "^5.1.4",
+        "workbox-cacheable-response": "^5.1.4",
+        "workbox-core": "^5.1.4",
+        "workbox-expiration": "^5.1.4",
+        "workbox-google-analytics": "^5.1.4",
+        "workbox-navigation-preload": "^5.1.4",
+        "workbox-precaching": "^5.1.4",
+        "workbox-range-requests": "^5.1.4",
+        "workbox-routing": "^5.1.4",
+        "workbox-strategies": "^5.1.4",
+        "workbox-streams": "^5.1.4",
+        "workbox-sw": "^5.1.4",
+        "workbox-window": "^5.1.4"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M="
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY="
+        }
+      }
+    },
+    "workbox-cacheable-response": {
+      "version": "5.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/workbox-cacheable-response/-/workbox-cacheable-response-5.1.4.tgz",
+      "integrity": "sha1-n/JuE2YhS90Fz1pD2pMFsnQHilQ=",
+      "requires": {
+        "workbox-core": "^5.1.4"
+      }
+    },
+    "workbox-core": {
+      "version": "5.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/workbox-core/-/workbox-core-5.1.4.tgz",
+      "integrity": "sha1-i7+yNi7N/zDiXRI8gseaxl2SZPQ="
+    },
+    "workbox-expiration": {
+      "version": "5.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/workbox-expiration/-/workbox-expiration-5.1.4.tgz",
+      "integrity": "sha1-krXfRh6BJhFJQ6OxXFXk7LkgsWM=",
+      "requires": {
+        "workbox-core": "^5.1.4"
+      }
+    },
+    "workbox-google-analytics": {
+      "version": "5.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/workbox-google-analytics/-/workbox-google-analytics-5.1.4.tgz",
+      "integrity": "sha1-szdoBrGsfX34QYME03lwcZX6hRc=",
+      "requires": {
+        "workbox-background-sync": "^5.1.4",
+        "workbox-core": "^5.1.4",
+        "workbox-routing": "^5.1.4",
+        "workbox-strategies": "^5.1.4"
+      }
+    },
+    "workbox-navigation-preload": {
+      "version": "5.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/workbox-navigation-preload/-/workbox-navigation-preload-5.1.4.tgz",
+      "integrity": "sha1-MNG3INJqBe/F+hFQPlzB7Vp4kCo=",
+      "requires": {
+        "workbox-core": "^5.1.4"
+      }
+    },
+    "workbox-precaching": {
+      "version": "5.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/workbox-precaching/-/workbox-precaching-5.1.4.tgz",
+      "integrity": "sha1-h09+vddQ3T4EJJ766aGz9IKF/ms=",
+      "requires": {
+        "workbox-core": "^5.1.4"
+      }
+    },
+    "workbox-range-requests": {
+      "version": "5.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/workbox-range-requests/-/workbox-range-requests-5.1.4.tgz",
+      "integrity": "sha1-cGahLBId9lv3b98rCGgBaqK6uFk=",
+      "requires": {
+        "workbox-core": "^5.1.4"
+      }
+    },
+    "workbox-routing": {
+      "version": "5.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/workbox-routing/-/workbox-routing-5.1.4.tgz",
+      "integrity": "sha1-PozYa9O2VzSI0aLOc4XlR7VH6XA=",
+      "requires": {
+        "workbox-core": "^5.1.4"
+      }
+    },
+    "workbox-strategies": {
+      "version": "5.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/workbox-strategies/-/workbox-strategies-5.1.4.tgz",
+      "integrity": "sha1-lrFBjM395TVGEpFJZAdNRmxS0Iw=",
+      "requires": {
+        "workbox-core": "^5.1.4",
+        "workbox-routing": "^5.1.4"
+      }
+    },
+    "workbox-streams": {
+      "version": "5.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/workbox-streams/-/workbox-streams-5.1.4.tgz",
+      "integrity": "sha1-BXVOXjZnvcB43yyTFbP0EhDYysA=",
+      "requires": {
+        "workbox-core": "^5.1.4",
+        "workbox-routing": "^5.1.4"
+      }
+    },
+    "workbox-sw": {
+      "version": "5.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/workbox-sw/-/workbox-sw-5.1.4.tgz",
+      "integrity": "sha1-K7NMn3OB+Q2EzvZEgW1FFQAR09s="
+    },
+    "workbox-webpack-plugin": {
+      "version": "5.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/workbox-webpack-plugin/-/workbox-webpack-plugin-5.1.4.tgz",
+      "integrity": "sha1-e/6MFuQP6e2JNwgKx66ci94B55w=",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "fast-json-stable-stringify": "^2.0.0",
+        "source-map-url": "^0.4.0",
+        "upath": "^1.1.2",
+        "webpack-sources": "^1.3.0",
+        "workbox-build": "^5.1.4"
+      }
+    },
+    "workbox-window": {
+      "version": "5.1.4",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/workbox-window/-/workbox-window-5.1.4.tgz",
+      "integrity": "sha1-J0D33qf5O5kyYXmmLxzAyiyTyGM=",
+      "requires": {
+        "workbox-core": "^5.1.4"
+      }
+    },
+    "worker-farm": {
+      "version": "1.7.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/worker-farm/-/worker-farm-1.7.0.tgz",
+      "integrity": "sha1-JqlMU5G7ypJhUgAvabhKS/dy5ag=",
+      "requires": {
+        "errno": "~0.1.7"
+      }
+    },
+    "worker-rpc": {
+      "version": "0.1.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/worker-rpc/-/worker-rpc-0.1.1.tgz",
+      "integrity": "sha1-y1Zb1tcHGo8WZgaGBR6WmtMvVNU=",
+      "requires": {
+        "microevent.ts": "~0.1.1"
+      }
+    },
+    "wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI="
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha1-Vr1cWlxwSBzRnFcb05q5ZaXeVug=",
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "ws": {
+      "version": "7.5.5",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/ws/-/ws-7.5.5.tgz",
+      "integrity": "sha1-i0vEr1GM+r0Ec65PmRRCh7M+uIE="
+    },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha1-auc+Bt5NjG5H+fsYH3jWSK1FfGo="
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha1-Bg/hvLf5x2/ioX24apvDq4lCEMs="
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q="
+    },
+    "y18n": {
+      "version": "4.0.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha1-tfJZyCzW4zaSHv17/Yv1YN6e7t8="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI="
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha1-IwHF/78StGfejaIzOkWeKeeSDks="
+    },
+    "yargs": {
+      "version": "15.4.1",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
+      "requires": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha1-vmjEl1xrKr9GkjawyHA2L6sJp7A=",
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
+        }
+      }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs="
+    }
+  }
+}

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -28,8 +28,6 @@
     "@babel/core": "7.12.3",
     "@pmmmwh/react-refresh-webpack-plugin": "0.4.3",
     "@svgr/webpack": "5.5.0",
-    "@typescript-eslint/eslint-plugin": "^4.5.0",
-    "@typescript-eslint/parser": "^4.5.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.6.0",
     "babel-loader": "8.1.0",


### PR DESCRIPTION
`react-scripts` comes with several linting dependencies preinstalled, both directly in its package.json and via it installing `eslint-config-react-app`.

https://github.com/facebook/create-react-app/blob/main/packages/react-scripts/package.json#L46-L48

In our fork we uninstalled `eslint`, `eslint-config-react-app`, `eslint-webpack-plugin`.

We provide linting via [`eslint-config-skyscanner`](https://github.com/Skyscanner/eslint-config-skyscanner), but do not install this directly in `backpack-react-scripts` and allow consumers to optionally choose to install it or not.

In https://github.com/Skyscanner/eslint-config-skyscanner/pull/214 we add the TypeScript ESLint packages to `eslint-config-skyscanner`.

Following our own pattern this means they are no longer required in `backpack-react-scripts`.
