### PR TITLE
[ST-3979] Update @pmmmwh/react-refresh-webpack-plugin to 0.5.4

### DIFF
--- a/packages/react-scripts/CHANGELOG.md
+++ b/packages/react-scripts/CHANGELOG.md
@@ -1,6 +1,9 @@
 # `backpack-react-scripts` Change Log
 
 
+## 9.4.1
+- Update react-refresh to ^0.11.0
+
 ## 9.4.0
 
 - Uninstall `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser`. These must now be provided either by directly installing them in your project or by an upcoming version of `eslint-config-skyscanner`.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -62,7 +62,7 @@
     "prompts": "2.4.0",
     "react-app-polyfill": "^2.0.0",
     "react-dev-utils": "^11.0.3",
-    "react-refresh": "^0.8.3",
+    "react-refresh": "^0.11.0",
     "resolve": "1.18.1",
     "resolve-url-loader": "^3.1.2",
     "sass-loader": "7.3.1",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -26,7 +26,7 @@
   "types": "./lib/react-app.d.ts",
   "dependencies": {
     "@babel/core": "7.12.3",
-    "@pmmmwh/react-refresh-webpack-plugin": "0.4.3",
+    "@pmmmwh/react-refresh-webpack-plugin": "0.5.4",
     "@svgr/webpack": "5.5.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.6.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -26,7 +26,7 @@
   "types": "./lib/react-app.d.ts",
   "dependencies": {
     "@babel/core": "7.12.3",
-    "@pmmmwh/react-refresh-webpack-plugin": "0.5.4",
+    "@pmmmwh/react-refresh-webpack-plugin": "0.4.3",
     "@svgr/webpack": "5.5.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.6.0",

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyscanner/backpack-react-scripts",
-  "version": "9.4.0",
+  "version": "9.4.1",
   "description": "Backpack configuration and scripts for Create React App.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Updates @pmmmwh/react-refresh-webpack-plugin to version 0.5.4 in order to solve a Storybook issue. Storybook fails to start as it cannot find the default file for react-refresh. The [fix was introduced in react-refresh version 0.11.0](https://github.com/facebook/react/commit/7d0e4150aa939ea843ab22bece1a415cbf2416cf#diff-13696b178c34d191730fc2a063a5eb5a582767afc94333e64a905f6338fc26bd).