### PR TITLE
[LEOP-280]Upgrade sass-loader to v10.x

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -204,9 +204,7 @@ module.exports = function (webpackEnv) {
           {
             loader: require.resolve('resolve-url-loader'),
             options: {
-              sourceMap: isEnvProduction
-                ? shouldUseSourceMap
-                : isEnvDevelopment,
+              sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
               root: paths.appSrc,
             },
           },
@@ -219,7 +217,7 @@ module.exports = function (webpackEnv) {
               },
             },
           },
-        ].filter(Boolean)
+        ].filter(Boolean),
       );
     }
     return loaders;

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -204,7 +204,9 @@ module.exports = function (webpackEnv) {
           {
             loader: require.resolve('resolve-url-loader'),
             options: {
-              sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
+              sourceMap: isEnvProduction
+                ? shouldUseSourceMap
+                : isEnvDevelopment,
               root: paths.appSrc,
             },
           },
@@ -217,7 +219,7 @@ module.exports = function (webpackEnv) {
               },
             },
           },
-        ].filter(Boolean),
+        ].filter(Boolean)
       );
     }
     return loaders;
@@ -742,7 +744,9 @@ module.exports = function (webpackEnv) {
                 },
                 'sass-loader',
                 {
-                  functions: sassFunctions,
+                  sassOptions: {
+                    functions: sassFunctions,
+                  },
                 }
               ),
               // Don't consider CSS imports dead code even if the
@@ -781,7 +785,9 @@ module.exports = function (webpackEnv) {
                 },
                 'sass-loader',
                 {
-                  functions: sassFunctions,
+                  sassOptions: {
+                    functions: sassFunctions,
+                  },
                 }
               ),
             },

--- a/packages/react-scripts/config/webpack.config.ssr.js
+++ b/packages/react-scripts/config/webpack.config.ssr.js
@@ -200,9 +200,7 @@ module.exports = function (webpackEnv) {
           {
             loader: require.resolve('resolve-url-loader'),
             options: {
-              sourceMap: isEnvProduction
-                ? shouldUseSourceMap
-                : isEnvDevelopment,
+              sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
               root: paths.appSrc,
             },
           },
@@ -215,7 +213,7 @@ module.exports = function (webpackEnv) {
               },
             },
           },
-        ].filter(Boolean)
+        ].filter(Boolean),
       );
     }
     return loaders;

--- a/packages/react-scripts/config/webpack.config.ssr.js
+++ b/packages/react-scripts/config/webpack.config.ssr.js
@@ -200,7 +200,9 @@ module.exports = function (webpackEnv) {
           {
             loader: require.resolve('resolve-url-loader'),
             options: {
-              sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
+              sourceMap: isEnvProduction
+                ? shouldUseSourceMap
+                : isEnvDevelopment,
               root: paths.appSrc,
             },
           },
@@ -213,7 +215,7 @@ module.exports = function (webpackEnv) {
               },
             },
           },
-        ].filter(Boolean),
+        ].filter(Boolean)
       );
     }
     return loaders;
@@ -745,7 +747,9 @@ module.exports = function (webpackEnv) {
                 },
                 'sass-loader',
                 {
-                  functions: sassFunctions,
+                  sassOptions: {
+                    functions: sassFunctions,
+                  },
                 }
               ),
               // Don't consider CSS imports dead code even if the
@@ -785,7 +789,9 @@ module.exports = function (webpackEnv) {
                 },
                 'sass-loader',
                 {
-                  functions: sassFunctions,
+                  sassOptions: {
+                    functions: sassFunctions,
+                  },
                 }
               ),
             },

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -65,7 +65,7 @@
     "react-refresh": "^0.8.3",
     "resolve": "1.18.1",
     "resolve-url-loader": "^3.1.2",
-    "sass-loader": "7.3.1",
+    "sass-loader": "^10.2.1",
     "semver": "7.3.2",
     "style-loader": "1.3.0",
     "terser-webpack-plugin": "4.2.3",


### PR DESCRIPTION
For sass-loader 8.0.0 and higher, the default number of threads used is 4, and thread size can be configured by setting the UV_THREADPOOL_SIZE env var, it can improve the build performance.
Detail: https://confluence.skyscannertools.net/display/LEOP/Standardizing+backpack-react-scripts%28BRS%29+As+The+Only+Build+Tool
