### PR TITLE
[LEOP-316]Extract babelIncludePrefixes feature

### DIFF
--- a/packages/react-scripts/backpack-addons/README.md
+++ b/packages/react-scripts/backpack-addons/README.md
@@ -1,4 +1,4 @@
-Our react scripts fork includes a number of custom configuration items in order to support building web products at Skyscanner. The table below will dive into what each of the configs do
+Our react scripts fork includes a number of custom configuration items in order to support building web products at Skyscanner. The table below will describe what each of the configs do
 
 | Feature | Description | Default Value |
 |:---|:--|:---|

--- a/packages/react-scripts/backpack-addons/README.md
+++ b/packages/react-scripts/backpack-addons/README.md
@@ -1,0 +1,5 @@
+Our react scripts fork includes a number of custom configuration items in order to support building web products at Skyscanner. The table below will dive into what each of the configs do
+
+| Feature | Description | Default Value |
+|:---|:--|:---|
+| **babelIncludePrefixes** | Array of module name prefixes to opt into babel compilation. <br> Default includes **@skyscanner/bpk-, bpk- and saddlebag-** packages by default to be compiled | **[@skyscanner/bpk-, bpk- and saddlebag-]** |

--- a/packages/react-scripts/backpack-addons/babelIncludePrefixes.js
+++ b/packages/react-scripts/backpack-addons/babelIncludePrefixes.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const paths = require("../config/paths");
+const appPackageJson = require(paths.appPackageJson);
+const bpkReactScriptsConfig = appPackageJson["backpack-react-scripts"] || {};
+const customModuleRegexes = bpkReactScriptsConfig.babelIncludePrefixes
+  ? bpkReactScriptsConfig.babelIncludePrefixes.map(
+      (prefix) => new RegExp(`node_modules[\\/]${prefix}`)
+    )
+  : [];
+
+// Backpack / saddlebag node module regexes
+const backpackModulesRegex = /node_modules[\\/]bpk-/;
+const saddlebagModulesRegex = /node_modules[\\/]saddlebag-/;
+const scopedBackpackModulesRegex = /node_modules[\\/]@skyscanner[\\/]bpk-/;
+
+module.exports = () => {
+  return [
+    paths.appSrc,
+    backpackModulesRegex,
+    saddlebagModulesRegex,
+    scopedBackpackModulesRegex,
+    ...customModuleRegexes,
+  ];
+};

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -61,11 +61,6 @@ const getCSSModuleLocalIdent = require('../utils/getCSSModuleLocalIdentWithProje
 const sassFunctions = require('../utils/sassFunction');
 const camelCase = require('lodash/camelCase');
 const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
-const customModuleRegexes = bpkReactScriptsConfig.babelIncludePrefixes
-  ? bpkReactScriptsConfig.babelIncludePrefixes.map(
-      prefix => new RegExp(`node_modules[\\/]${prefix}`)
-    )
-  : [];
 const cssModulesEnabled = bpkReactScriptsConfig.cssModules !== false;
 const crossOriginLoading = bpkReactScriptsConfig.crossOriginLoading || false;
 const sriEnabled = bpkReactScriptsConfig.sriEnabled || false;
@@ -489,13 +484,7 @@ module.exports = function (webpackEnv) {
             // The preset includes JSX, Flow, TypeScript, and some ESnext features.
             {
               test: /\.(js|mjs|jsx|ts|tsx)$/,
-              include: [
-                paths.appSrc,
-                backpackModulesRegex,
-                saddlebagModulesRegex,
-                scopedBackpackModulesRegex,
-                ...customModuleRegexes,
-              ],
+              include: require('../backpack-addons/babelIncludePrefixes')(),  // #backpack-addon babelIncludePrefixes
               loader: require.resolve('babel-loader'),
               options: {
                 customize: require.resolve(
@@ -559,13 +548,7 @@ module.exports = function (webpackEnv) {
             {
               test: /\.(js|mjs|jsx|ts|tsx)$/,
               exclude: /\.storybook/,
-              include: [
-                paths.appSrc,
-                backpackModulesRegex,
-                saddlebagModulesRegex,
-                scopedBackpackModulesRegex,
-                ...customModuleRegexes,
-              ],
+              include: require('../backpack-addons/babelIncludePrefixes')(),  // #backpack-addon babelIncludePrefixes
               use: [
                 {
                   loader: require.resolve('thread-loader'),

--- a/packages/react-scripts/config/webpack.config.ssr.js
+++ b/packages/react-scripts/config/webpack.config.ssr.js
@@ -61,11 +61,6 @@ const getCSSModuleLocalIdent = require('../utils/getCSSModuleLocalIdentWithProje
 const sassFunctions = require('../utils/sassFunction');
 // const camelCase = require('lodash/camelCase');
 const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
-const customModuleRegexes = bpkReactScriptsConfig.babelIncludePrefixes
-  ? bpkReactScriptsConfig.babelIncludePrefixes.map(
-      prefix => new RegExp(`node_modules[\\/]${prefix}`)
-    )
-  : [];
 const cssModulesEnabled = bpkReactScriptsConfig.cssModules !== false;
 // const crossOriginLoading = bpkReactScriptsConfig.crossOriginLoading || false;
 // const sriEnabled = bpkReactScriptsConfig.sriEnabled || false;
@@ -491,13 +486,7 @@ module.exports = function (webpackEnv) {
             // The preset includes JSX, Flow, TypeScript, and some ESnext features.
             {
               test: /\.(js|mjs|jsx|ts|tsx)$/,
-              include: [
-                paths.appSrc,
-                backpackModulesRegex,
-                saddlebagModulesRegex,
-                scopedBackpackModulesRegex,
-                ...customModuleRegexes,
-              ],
+              include: require('../backpack-addons/babelIncludePrefixes')(),  // #backpack-addon babelIncludePrefixes
               loader: require.resolve('babel-loader'),
               options: {
                 customize: require.resolve(
@@ -561,13 +550,7 @@ module.exports = function (webpackEnv) {
             {
               test: /\.(js|mjs|jsx|ts|tsx)$/,
               exclude: /\.storybook/,
-              include: [
-                paths.appSrc,
-                backpackModulesRegex,
-                saddlebagModulesRegex,
-                scopedBackpackModulesRegex,
-                ...customModuleRegexes,
-              ],
+              include: require('../backpack-addons/babelIncludePrefixes')(),  // #backpack-addon babelIncludePrefixes
               use: [
                 // {
                 //   loader: require.resolve('thread-loader'),


### PR DESCRIPTION
[LEOP-316](https://gojira.skyscanner.net/browse/LEOP-316)

- Extracting babelIncludePrefixes feature to separate file
- Using `require(.../backpack-addons/...)` instead of writing it inline.
- Add README.md to describe the feature