### PR TITLE
[LEOP-316]Extract crossOriginLoading and sriEnabled features

### DIFF
--- a/packages/react-scripts/backpack-addons/README.md
+++ b/packages/react-scripts/backpack-addons/README.md
@@ -1,0 +1,6 @@
+Our react scripts fork includes a number of custom configuration items in order to support building web products at Skyscanner. The table below will describe what each of the configs do
+
+| Feature | Description | Default Value |
+|:---|:--|:---|
+| **sriEnabled** | Determines if Subresource Intergrity is used during build to add an integrity hash for files. <br> The SRI is a security feature to enable browsers to verify the files they fetch are unmodified. <br> If enabled crossOriginLoading value is overriden with anonymous to allow output to have integrity value <br> See [webpack subresource integrity docs](https://github.com/waysact/webpack-subresource-integrity/blob/master/README.md) | **false** (this is currently the default in the future security may want to make it true by default but pending them still trying things about) |
+| **crossOriginLoading** | Option to enable cross origin loading of chunks to modify the default webpack behaviour of being false. <br> Docs: https://webpack.js.org/configuration/output/#outputcrossoriginloading | **false** |

--- a/packages/react-scripts/backpack-addons/crossOriginLoading.js
+++ b/packages/react-scripts/backpack-addons/crossOriginLoading.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const paths = require("../config/paths");
+const appPackageJson = require(paths.appPackageJson);
+const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
+const crossOriginLoading = bpkReactScriptsConfig.crossOriginLoading || false;
+const sriEnabled = bpkReactScriptsConfig.sriEnabled || false;
+
+module.exports = {
+    crossOriginLoading: sriEnabled ? 'anonymous' : crossOriginLoading
+}

--- a/packages/react-scripts/backpack-addons/sriEnabled.js
+++ b/packages/react-scripts/backpack-addons/sriEnabled.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const SubresourceIntegrityPlugin = require("webpack-subresource-integrity");
+const paths = require("../config/paths");
+const appPackageJson = require(paths.appPackageJson);
+const bpkReactScriptsConfig = appPackageJson["backpack-react-scripts"] || {};
+const sriEnabled = bpkReactScriptsConfig.sriEnabled || false;
+
+module.exports = () => {
+  return (
+    // Calculate and inject Subresource Integrity (SRI) hashes
+    // https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
+    // This is a security feature that enables browsers to verify that resources
+    // they fetch (for example, from a CDN) are delivered without unexpected manipulation.
+    sriEnabled &&
+    new SubresourceIntegrityPlugin({
+      enabled: true,
+      hashFuncNames: ["sha384"],
+    })
+  );
+};

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -21,7 +21,6 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const safePostCssParser = require('postcss-safe-parser');
 const ManifestPlugin = require('webpack-manifest-plugin');
-const SubresourceIntegrityPlugin = require('webpack-subresource-integrity');
 const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
 const WorkboxWebpackPlugin = require('workbox-webpack-plugin');
 const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
@@ -67,8 +66,6 @@ const customModuleRegexes = bpkReactScriptsConfig.babelIncludePrefixes
     )
   : [];
 const cssModulesEnabled = bpkReactScriptsConfig.cssModules !== false;
-const crossOriginLoading = bpkReactScriptsConfig.crossOriginLoading || false;
-const sriEnabled = bpkReactScriptsConfig.sriEnabled || false;
 const supressCssWarnings = bpkReactScriptsConfig.ignoreCssWarnings || false;
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
@@ -260,7 +257,7 @@ module.exports = function (webpackEnv) {
           ]
         : paths.appIndexJs,
     output: {
-      crossOriginLoading: sriEnabled ? 'anonymous' : crossOriginLoading,
+      ...require('../backpack-addons/crossOriginLoading'),  // #backpack-addon crossOriginLoading
       // The build folder.
       path: isEnvProduction ? paths.appBuild : undefined,
       // Add /* filename */ comments to generated require()s in the output.
@@ -938,15 +935,7 @@ module.exports = function (webpackEnv) {
           };
         },
       }),
-      // Calculate and inject Subresource Integrity (SRI) hashes
-      // https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
-      // This is a security feature that enables browsers to verify that resources
-      // they fetch (for example, from a CDN) are delivered without unexpected manipulation.
-      sriEnabled &&
-        new SubresourceIntegrityPlugin({
-          enabled: true,
-          hashFuncNames: ['sha384'],
-        }),
+      require('../backpack-addons/sriEnabled')(), // #backpack-addon sriEnabled
       // Moment.js is an extremely popular library that bundles large locale files
       // by default due to how webpack interprets its code. This is a practical
       // solution that requires the user to opt into importing specific locales.


### PR DESCRIPTION
[LEOP-316](https://gojira.skyscanner.net/browse/LEOP-316)

- Extracting crossOriginLoading and sriEnabled features to separate file
- Use require(.../backpack-addons/...) instead of writing it inline
- Add README.md to describe the feature