### PR TITLE
[LEOP-316]Extract ignoreCssWarnings feature

### DIFF
--- a/packages/react-scripts/backpack-addons/README.md
+++ b/packages/react-scripts/backpack-addons/README.md
@@ -1,0 +1,5 @@
+Our react scripts fork includes a number of custom configuration items in order to support building web products at Skyscanner. The table below will describe what each of the configs do
+
+| Feature | Description | Default Value |
+|:---|:--|:---|
+| **ignoreCssWarnings** | Provides the ablity to supress CSS ordering warnings when its safe and ordering is not of a concern on the output <br> See [mini css extract plugin docs](https://github.com/webpack-contrib/mini-css-extract-plugin#remove-order-warnings) | **false** - by default we should care about order as it can sometimes have an output impact |

--- a/packages/react-scripts/backpack-addons/ignoreCssWarnings.js
+++ b/packages/react-scripts/backpack-addons/ignoreCssWarnings.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const paths = require('../config/paths');
+const appPackageJson = require(paths.appPackageJson);
+const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
+const ignoreCssWarnings = bpkReactScriptsConfig.ignoreCssWarnings || false;
+
+module.exports = {
+    ignoreOrder: ignoreCssWarnings
+}

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -69,7 +69,6 @@ const customModuleRegexes = bpkReactScriptsConfig.babelIncludePrefixes
 const cssModulesEnabled = bpkReactScriptsConfig.cssModules !== false;
 const crossOriginLoading = bpkReactScriptsConfig.crossOriginLoading || false;
 const sriEnabled = bpkReactScriptsConfig.sriEnabled || false;
-const supressCssWarnings = bpkReactScriptsConfig.ignoreCssWarnings || false;
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
 const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';
@@ -912,7 +911,7 @@ module.exports = function (webpackEnv) {
           // both options are optional
           filename: 'static/css/[name].[contenthash:8].css',
           chunkFilename: 'static/css/[name].[contenthash:8].chunk.css',
-          ignoreOrder: supressCssWarnings,
+          ...require('../backpack-addons/ignoreCssWarnings')  // #backpack-addon ignoreCssWarnings
         }),
       // Generate an asset manifest file with the following content:
       // - "files" key: Mapping of all asset filenames to their corresponding


### PR DESCRIPTION
[LEOP-316](https://gojira.skyscanner.net/browse/LEOP-316)

- Extracting ignoreCssWarnings feature to separate file
- Use `require(.../backpack-addons/...)` instead of writing it inline
- Add README.md to describe the feature