### PR TITLE
[LEOP-317]Extract splitChunks

### DIFF
--- a/packages/react-scripts/backpack-addons/splitChunks.js
+++ b/packages/react-scripts/backpack-addons/splitChunks.js
@@ -5,6 +5,9 @@ const appPackageJson = require(paths.appPackageJson);
 const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
 
 module.exports = (isEnvDevelopment) => {
+  // Automatically split vendor and commons
+  // https://twitter.com/wSokra/status/969633336732905474
+  // https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
   return {
     splitChunks: bpkReactScriptsConfig.enableAutomaticChunking
     ? {

--- a/packages/react-scripts/backpack-addons/splitChunks.js
+++ b/packages/react-scripts/backpack-addons/splitChunks.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const paths = require('../config/paths');
+const appPackageJson = require(paths.appPackageJson);
+const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
+
+module.exports = (isEnvDevelopment) => {
+  return {
+    splitChunks: bpkReactScriptsConfig.enableAutomaticChunking
+    ? {
+      chunks: 'all',
+      name: isEnvDevelopment,
+      cacheGroups: bpkReactScriptsConfig.vendorsChunkRegex
+        ? {
+            vendors: {
+              test: new RegExp(bpkReactScriptsConfig.vendorsChunkRegex),
+              name: 'vendor'
+            },
+          }
+        : {},
+      }
+    : {}
+  }
+};

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -360,26 +360,7 @@ module.exports = function (webpackEnv) {
           },
         }),
       ],
-      // Automatically split vendor and commons
-      // https://twitter.com/wSokra/status/969633336732905474
-      // https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
-      // splitChunks: {
-      //   chunks: 'all',
-      //   name: false,
-      // },
-      splitChunks: bpkReactScriptsConfig.enableAutomaticChunking
-        ? {
-            chunks: 'all',
-            name: isEnvDevelopment,
-            cacheGroups: bpkReactScriptsConfig.vendorsChunkRegex
-              ? {
-                  vendors: {
-                    test: new RegExp(bpkReactScriptsConfig.vendorsChunkRegex),
-                  },
-                }
-              : {},
-          }
-        : {},
+      ...require('../backpack-addon/splitChunks')(isEnvDevelopment),  // #backpack-addons splitChunks
       // Keep the runtime chunk separated to enable long term caching
       // https://twitter.com/wSokra/status/969679223278505985
       // https://github.com/facebook/create-react-app/issues/5358

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -360,7 +360,7 @@ module.exports = function (webpackEnv) {
           },
         }),
       ],
-      ...require('../backpack-addon/splitChunks')(isEnvDevelopment),  // #backpack-addons splitChunks
+      ...require('../backpack-addons/splitChunks')(isEnvDevelopment),  // #backpack-addons splitChunks
       // Keep the runtime chunk separated to enable long term caching
       // https://twitter.com/wSokra/status/969679223278505985
       // https://github.com/facebook/create-react-app/issues/5358


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
Splitchunks can separate common code from chunks, and splitchunks can split modules according to `cacheGroups`. Webpack has two groups, vendors and Default, by default, and you can also add groups by redefining the properties in both groups.

step:

- extract splitChunks to backpack-addons
- test for banana
