### PR TITLE
[LEOP-317]Extract externals

### DIFF
--- a/packages/react-scripts/backpack-addons/externals.js
+++ b/packages/react-scripts/backpack-addons/externals.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const paths = require('../config/paths');
+const appPackageJson = require(paths.appPackageJson);
+const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
+
+function externals(isEnvProduction) {
+  if (!isEnvProduction) {
+    return {
+      externals: {},
+    }
+  }
+  return {
+    externals: bpkReactScriptsConfig.externals || {},
+  }
+}
+
+function ssrExternals() {
+  return {
+    externals: bpkReactScriptsConfig.ssrExternals || [],
+  }
+}
+
+module.exports = {
+  externals,
+  ssrExternals
+};

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -392,7 +392,7 @@ module.exports = function (webpackEnv) {
           }
         : false,
     },
-    externals: isEnvProduction ? bpkReactScriptsConfig.externals || {} : {},
+    ...require('../backpack-addons/externals').externals(isEnvProduction), // #backpack-addons externals
     resolve: {
       // This allows you to set a fallback for where webpack should look for modules.
       // We placed these paths second because we want `node_modules` to "win"

--- a/packages/react-scripts/config/webpack.config.ssr.js
+++ b/packages/react-scripts/config/webpack.config.ssr.js
@@ -394,7 +394,7 @@ module.exports = function (webpackEnv) {
       //   : false,
       runtimeChunk: false,
     },
-    externals: bpkReactScriptsConfig.ssrExternals || [],
+    ...require('../backpack-addons/externals').ssrExternals(), // #backpack-addons externals
     resolve: {
       // This allows you to set a fallback for where webpack should look for modules.
       // We placed these paths second because we want `node_modules` to "win"


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
externals: Prevent bundling of certain imported packages and instead retrieve these external dependencies at runtime.
For example, to include jQuery from a CDN instead of bundling it.

step:

- extract externals to backpack-addons
- test for banana