### PR TITLE
[LEOP-317]Extract amdExcludes

### DIFF
--- a/packages/react-scripts/backpack-addons/amdExcludes.js
+++ b/packages/react-scripts/backpack-addons/amdExcludes.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const paths = require('../config/paths');
+const appPackageJson = require(paths.appPackageJson);
+const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
+
+module.exports = {
+  test: new RegExp(
+    `(^|/)(${(bpkReactScriptsConfig.amdExcludes || [])
+    .concat('lodash')
+    .join('|')})(/|.|$)`
+  ),
+  parser: {
+    amd: false,
+  }
+}; 

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -464,16 +464,7 @@ module.exports = function (webpackEnv) {
                 name: 'static/media/[name].[hash:8].[ext]',
               },
             },
-            {
-              test: new RegExp(
-                `(^|/)(${(bpkReactScriptsConfig.amdExcludes || [])
-                  .concat('lodash')
-                  .join('|')})(/|.|$)`
-              ),
-              parser: {
-                amd: false,
-              },
-            },
+            require('../backpack-addons/amdExcludes'),  // #backpack-addons amdExcludes
             // "url" loader works like "file" loader except that it embeds assets
             // smaller than specified limit in bytes as data URLs to avoid requests.
             // A missing `test` is equivalent to a match.

--- a/packages/react-scripts/config/webpack.config.ssr.js
+++ b/packages/react-scripts/config/webpack.config.ssr.js
@@ -466,16 +466,7 @@ module.exports = function (webpackEnv) {
                 name: 'static/media/[name].[hash:8].[ext]',
               },
             },
-            {
-              test: new RegExp(
-                `(^|/)(${(bpkReactScriptsConfig.amdExcludes || [])
-                  .concat('lodash')
-                  .join('|')})(/|.|$)`
-              ),
-              parser: {
-                amd: false,
-              },
-            },
+            require('../backpack-addons/amdExcludes'),  // #backpack-addons amdExcludes
             // "url" loader works like "file" loader except that it embeds assets
             // smaller than specified limit in bytes as data URLs to avoid requests.
             // A missing `test` is equivalent to a match.


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
Test disable AMD parsing when filename contains `lodash` or `amdExcludes`

step:

- extract amdExcludes to backpack-addons
- test for banana