### PR TITLE
[LEOP-317]Fix not find encodebase64 function error

### DIFF
--- a/packages/react-scripts/backpack-addons/sassFunctions.js
+++ b/packages/react-scripts/backpack-addons/sassFunctions.js
@@ -3,10 +3,12 @@ const sass = require('node-sass');
 
 module.exports = {
   sassOptions: {
-    'encodebase64($string)': str => {
-      const buffer = Buffer.from(str.getValue());
-
-      return sass.types.String(buffer.toString('base64'));
+    functions: {
+      'encodebase64($string)': str => {
+        const buffer = Buffer.from(str.getValue());
+  
+        return sass.types.String(buffer.toString('base64'));
+      }
     }
   }
 };

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -196,7 +196,7 @@ module.exports = function (webpackEnv) {
           {
             loader: require.resolve(preProcessor),
             options: {
-              ...preProcessorOptions,
+              ...preProcessorOptions,  // #backpack-addons sassFunctions
               ...{
                 sourceMap: true,
               },


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
It shows this error when running npm run build in banana:
![image](https://user-images.githubusercontent.com/86700834/156288078-c7aa064a-e64f-43f1-a222-33b8051586db.png)
`./src/components/DetailsPanel/LegSegmentSummary/Times/Times.scss
SassError: Could not find encodebase64 function. Refer to https://backpack.github.io/sassdoc/#svgs-mixin-bpk-icon on how to provide it to node-sass.
        on line 109 of node_modules/bpk-mixins/src/mixins/_svgs.scss, in mixin `bpk-icon`
        from line 31 of src/components/DetailsPanel/LegSegmentSummary/Times/Times.scss
>>     @error $err;
`