### PR TITLE
[LEOP-287]Part1-Apply externals to CRA5

### DIFF
--- a/packages/react-scripts/backpack-addons/externals.js
+++ b/packages/react-scripts/backpack-addons/externals.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const paths = require('../config/paths');
+const appPackageJson = require(paths.appPackageJson);
+const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
+
+function externals(isEnvProduction) {
+  if (!isEnvProduction) {
+    return {
+      externals: {},
+    }
+  }
+  return {
+    externals: bpkReactScriptsConfig.externals || {},
+  }
+}
+
+function ssrExternals() {
+  return {
+    externals: bpkReactScriptsConfig.ssrExternals || [],
+  }
+}
+
+module.exports = {
+  externals,
+  ssrExternals
+};

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -300,6 +300,7 @@ module.exports = function (webpackEnv) {
         new CssMinimizerPlugin(),
       ],
     },
+    ...require('../backpack-addons/externals').externals(isEnvProduction), // #backpack-addons externals
     resolve: {
       // This allows you to set a fallback for where webpack should look for modules.
       // We placed these paths second because we want `node_modules` to "win"


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
JIRA: https://gojira.skyscanner.net/browse/LEOP-287

externals: Prevent bundling of certain imported packages and instead retrieve these external dependencies at runtime.
For example, to include jQuery from a CDN instead of bundling it.

Change file

- Add backpack-addons/externals.js
- update webpack.config.js