### PR TITLE
[LEOP-287]Part2-Apply splitChunks to CRA5

### DIFF
--- a/packages/react-scripts/backpack-addons/splitChunks.js
+++ b/packages/react-scripts/backpack-addons/splitChunks.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const paths = require('../config/paths');
+const appPackageJson = require(paths.appPackageJson);
+const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
+
+module.exports = (isEnvDevelopment) => {
+  // Automatically split vendor and commons
+  // https://twitter.com/wSokra/status/969633336732905474
+  // https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
+  return {
+    splitChunks: bpkReactScriptsConfig.enableAutomaticChunking
+    ? {
+      chunks: 'all',
+      name: isEnvDevelopment,
+      cacheGroups: bpkReactScriptsConfig.vendorsChunkRegex
+        ? {
+            vendors: {
+              test: new RegExp(bpkReactScriptsConfig.vendorsChunkRegex)
+            },
+          }
+        : {},
+      }
+    : {}
+  }
+};

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -299,6 +299,7 @@ module.exports = function (webpackEnv) {
         // This is only used in production mode
         new CssMinimizerPlugin(),
       ],
+      ...require('../backpack-addons/splitChunks')(isEnvDevelopment),  // #backpack-addons splitChunks
     },
     resolve: {
       // This allows you to set a fallback for where webpack should look for modules.


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
JIRA: https://gojira.skyscanner.net/browse/LEOP-287

Splitchunks can separate common code from chunks, and splitchunks can split modules according to cacheGroups. Webpack has two groups, vendors and Default, by default, and you can also add groups by redefining the properties in both groups.

Change file:

- Add backpack-addons/splitChunks.js
- Update webpack.config.js