### PR TITLE
[LEOP-287]Part3-Apply runtimeChunk to CRA5

### DIFF
--- a/packages/react-scripts/backpack-addons/runtimeChunk.js
+++ b/packages/react-scripts/backpack-addons/runtimeChunk.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const paths = require('../config/paths');
+const appPackageJson = require(paths.appPackageJson);
+const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
+
+const runtimeChunk = {
+  runtimeChunk: bpkReactScriptsConfig.enableAutomaticChunking
+  ? {
+    name: entrypoint => `runtime-${entrypoint.name}`,
+  }
+  : false
+}
+
+const ssrRuntimeChunk = { 
+  runtimeChunk: false,
+}
+
+module.exports = {
+  runtimeChunk,
+  ssrRuntimeChunk
+};

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -299,6 +299,7 @@ module.exports = function (webpackEnv) {
         // This is only used in production mode
         new CssMinimizerPlugin(),
       ],
+      ...require('../backpack-addons/runtimeChunk').runtimeChunk, // #backpack-addons runtimeChunk
     },
     resolve: {
       // This allows you to set a fallback for where webpack should look for modules.


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
JIRA: https://gojira.skyscanner.net/browse/LEOP-287

runtimeChunk: Setting optimization.runtimeChunk to true adds an additional chunk containing only the runtime to each entrypoint.

Change file:

- Add backpack-addons/runtimeChunk.js
- Update webpack.config.js