### PR TITLE
[LEOP-287]Part5-Apply amdExcludes to CRA5

### DIFF
--- a/packages/react-scripts/backpack-addons/amdExcludes.js
+++ b/packages/react-scripts/backpack-addons/amdExcludes.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const paths = require('../config/paths');
+const appPackageJson = require(paths.appPackageJson);
+const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
+
+module.exports = {
+  test: new RegExp(
+    `(^|/)(${(bpkReactScriptsConfig.amdExcludes || [])
+    .concat('lodash')
+    .join('|')})(/|.|$)`
+  ),
+  parser: {
+    amd: false,
+  }
+}; 

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -371,6 +371,7 @@ module.exports = function (webpackEnv) {
                 },
               },
             },
+            require('../backpack-addons/amdExcludes'),  // #backpack-addons amdExcludes
             // "url" loader works like "file" loader except that it embeds assets
             // smaller than specified limit in bytes as data URLs to avoid requests.
             // A missing `test` is equivalent to a match.


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
JIRA: https://gojira.skyscanner.net/browse/LEOP-287

Test disable AMD parsing when filename contains `lodash` or `amdExcludes`

Change file:

- Add backpack-addons/amdExcludes.js
- Update webpack.config.js