### PR TITLE
[No JIRA]SplitChunks remove name and SubresourceIntegrityPlugin use new import syntax

### DIFF
--- a/packages/react-scripts/backpack-addons/splitChunks.js
+++ b/packages/react-scripts/backpack-addons/splitChunks.js
@@ -19,16 +19,24 @@ module.exports = (isEnvDevelopment) => {
   // Automatically split vendor and commons
   // https://twitter.com/wSokra/status/969633336732905474
   // https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
+  if(!bpkReactScriptsConfig.enableAutomaticChunking){
+    return {
+      splitChunks: {},
+    };
+  }
+  
+  if(isEnvDevelopment) {
+    return {
+      splitChunks: {
+        ...chunksAndGroups,
+      },
+    };
+  }
+  
   return {
-    splitChunks: bpkReactScriptsConfig.enableAutomaticChunking
-      ? isEnvDevelopment 
-        ? {
-            ...chunksAndGroups,
-          }
-        : {
-            ...chunksAndGroups,
-            name: false,
-          }
-      : {},
+    splitChunks: {
+      ...chunksAndGroups,
+      name: false,
+    },
   };
 };

--- a/packages/react-scripts/backpack-addons/splitChunks.js
+++ b/packages/react-scripts/backpack-addons/splitChunks.js
@@ -4,13 +4,13 @@ const paths = require('../config/paths');
 const appPackageJson = require(paths.appPackageJson);
 const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
 
-module.exports = isEnvDevelopment => {
+module.exports = (isEnvDevelopment) => {
   // Automatically split vendor and commons
   // https://twitter.com/wSokra/status/969633336732905474
   // https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
-  return {
-    splitChunks: bpkReactScriptsConfig.enableAutomaticChunking
-      ? isEnvDevelopment
+  if(isEnvDevelopment){
+    return {
+      splitChunks: bpkReactScriptsConfig.enableAutomaticChunking
         ? {
             chunks: 'all',
             cacheGroups: bpkReactScriptsConfig.vendorsChunkRegex
@@ -21,17 +21,22 @@ module.exports = isEnvDevelopment => {
                 }
               : {},
           }
-        : {
-            chunks: 'all',
-            name: false,
-            cacheGroups: bpkReactScriptsConfig.vendorsChunkRegex
-              ? {
-                  defaultVendors: {
-                    test: new RegExp(bpkReactScriptsConfig.vendorsChunkRegex),
-                  },
-                }
-              : {},
-          }
+        : {},
+    };
+  };
+  return {
+    splitChunks: bpkReactScriptsConfig.enableAutomaticChunking
+      ? {
+          chunks: 'all',
+          name: false,
+          cacheGroups: bpkReactScriptsConfig.vendorsChunkRegex
+            ? {
+                defaultVendors: {
+                  test: new RegExp(bpkReactScriptsConfig.vendorsChunkRegex),
+                },
+              }
+            : {},
+        }
       : {},
   };
 };

--- a/packages/react-scripts/backpack-addons/splitChunks.js
+++ b/packages/react-scripts/backpack-addons/splitChunks.js
@@ -19,24 +19,16 @@ module.exports = (isEnvDevelopment) => {
   // Automatically split vendor and commons
   // https://twitter.com/wSokra/status/969633336732905474
   // https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
-  if(!bpkReactScriptsConfig.enableAutomaticChunking){
-    return {
-      splitChunks: {},
-    };
-  }
-  
-  if(isEnvDevelopment) {
-    return {
-      splitChunks: {
-        ...chunksAndGroups,
-      },
-    };
-  }
-  
   return {
-    splitChunks: {
-      ...chunksAndGroups,
-      name: false,
-    },
+    splitChunks: bpkReactScriptsConfig.enableAutomaticChunking
+    ? isEnvDevelopment
+      ? {
+          ...chunksAndGroups,
+        }
+      : {
+          ...chunksAndGroups,
+          name: false,
+        }
+    : {}
   };
 };

--- a/packages/react-scripts/backpack-addons/splitChunks.js
+++ b/packages/react-scripts/backpack-addons/splitChunks.js
@@ -4,39 +4,31 @@ const paths = require('../config/paths');
 const appPackageJson = require(paths.appPackageJson);
 const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
 
+const chunksAndGroups = {
+  chunks: 'all',
+  cacheGroups: bpkReactScriptsConfig.vendorsChunkRegex
+    ? {
+        defaultVendors: {
+          test: new RegExp(bpkReactScriptsConfig.vendorsChunkRegex),
+        },
+      }
+    : {},
+};
+
 module.exports = (isEnvDevelopment) => {
   // Automatically split vendor and commons
   // https://twitter.com/wSokra/status/969633336732905474
   // https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
-  if(isEnvDevelopment){
-    return {
-      splitChunks: bpkReactScriptsConfig.enableAutomaticChunking
-        ? {
-            chunks: 'all',
-            cacheGroups: bpkReactScriptsConfig.vendorsChunkRegex
-              ? {
-                  defaultVendors: {
-                    test: new RegExp(bpkReactScriptsConfig.vendorsChunkRegex),
-                  },
-                }
-              : {},
-          }
-        : {},
-    };
-  };
   return {
     splitChunks: bpkReactScriptsConfig.enableAutomaticChunking
-      ? {
-          chunks: 'all',
-          name: false,
-          cacheGroups: bpkReactScriptsConfig.vendorsChunkRegex
-            ? {
-                defaultVendors: {
-                  test: new RegExp(bpkReactScriptsConfig.vendorsChunkRegex),
-                },
-              }
-            : {},
-        }
+      ? isEnvDevelopment 
+        ? {
+            ...chunksAndGroups,
+          }
+        : {
+            ...chunksAndGroups,
+            name: false,
+          }
       : {},
   };
 };

--- a/packages/react-scripts/backpack-addons/splitChunks.js
+++ b/packages/react-scripts/backpack-addons/splitChunks.js
@@ -4,23 +4,34 @@ const paths = require('../config/paths');
 const appPackageJson = require(paths.appPackageJson);
 const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
 
-module.exports = (isEnvDevelopment) => {
+module.exports = isEnvDevelopment => {
   // Automatically split vendor and commons
   // https://twitter.com/wSokra/status/969633336732905474
   // https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
   return {
     splitChunks: bpkReactScriptsConfig.enableAutomaticChunking
-    ? {
-      chunks: 'all',
-      name: isEnvDevelopment,
-      cacheGroups: bpkReactScriptsConfig.vendorsChunkRegex
+      ? isEnvDevelopment
         ? {
-            defaultVendors: {
-              test: new RegExp(bpkReactScriptsConfig.vendorsChunkRegex)
-            },
+            chunks: 'all',
+            cacheGroups: bpkReactScriptsConfig.vendorsChunkRegex
+              ? {
+                  defaultVendors: {
+                    test: new RegExp(bpkReactScriptsConfig.vendorsChunkRegex),
+                  },
+                }
+              : {},
           }
-        : {},
-      }
-    : {}
-  }
+        : {
+            chunks: 'all',
+            name: false,
+            cacheGroups: bpkReactScriptsConfig.vendorsChunkRegex
+              ? {
+                  defaultVendors: {
+                    test: new RegExp(bpkReactScriptsConfig.vendorsChunkRegex),
+                  },
+                }
+              : {},
+          }
+      : {},
+  };
 };

--- a/packages/react-scripts/backpack-addons/sriEnabled.js
+++ b/packages/react-scripts/backpack-addons/sriEnabled.js
@@ -1,9 +1,9 @@
-'use strict';
+"use strict";
 
-const { SubresourceIntegrityPlugin } = require('webpack-subresource-integrity');
-const paths = require('../config/paths');
+const { SubresourceIntegrityPlugin } = require("webpack-subresource-integrity");
+const paths = require("../config/paths");
 const appPackageJson = require(paths.appPackageJson);
-const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
+const bpkReactScriptsConfig = appPackageJson["backpack-react-scripts"] || {};
 const sriEnabled = bpkReactScriptsConfig.sriEnabled || false;
 
 module.exports = () => {
@@ -15,7 +15,7 @@ module.exports = () => {
     sriEnabled &&
     new SubresourceIntegrityPlugin({
       enabled: true,
-      hashFuncNames: ['sha384'],
+      hashFuncNames: ["sha384"],
     })
   );
 };

--- a/packages/react-scripts/backpack-addons/sriEnabled.js
+++ b/packages/react-scripts/backpack-addons/sriEnabled.js
@@ -1,9 +1,9 @@
-"use strict";
+'use strict';
 
-const SubresourceIntegrityPlugin = require("webpack-subresource-integrity");
-const paths = require("../config/paths");
+const { SubresourceIntegrityPlugin } = require('webpack-subresource-integrity');
+const paths = require('../config/paths');
 const appPackageJson = require(paths.appPackageJson);
-const bpkReactScriptsConfig = appPackageJson["backpack-react-scripts"] || {};
+const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
 const sriEnabled = bpkReactScriptsConfig.sriEnabled || false;
 
 module.exports = () => {
@@ -15,7 +15,7 @@ module.exports = () => {
     sriEnabled &&
     new SubresourceIntegrityPlugin({
       enabled: true,
-      hashFuncNames: ["sha384"],
+      hashFuncNames: ['sha384'],
     })
   );
 };


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
Splitchunks: in webpack5, optimization.splitChunks name: true removed: Automatic names are no longer supported, see [here](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#changes-to-the-structure).
sriEnabled: migrate v1 to v5 use new import syntax, see [here](https://github.com/waysact/webpack-subresource-integrity/blob/next/MIGRATE-v1-to-v5.md#migrate-from-version-1x-to-version-5x).

change files:

- splitChunks: remove `name` when development is ture
- sirEnabled: change `const SubresourceIntegrityPlugin = require("webpack-subresource-integrity");` to `const { SubresourceIntegrityPlugin } = require("webpack-subresource-integrity")`