### PR TITLE
[NOJIRA] Support package exports

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -43,6 +43,7 @@
     "css-loader": "4.3.0",
     "dotenv": "8.2.0",
     "dotenv-expand": "5.1.0",
+    "enhanced-resolve": "^5.9.3",
     "file-loader": "6.1.1",
     "fs-extra": "^9.0.1",
     "html-webpack-plugin": "4.5.0",

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -8,6 +8,7 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 const chalk = require('react-dev-utils/chalk');
 const paths = require('../../config/paths');
 const modules = require('../../config/modules');
@@ -83,6 +84,8 @@ module.exports = (resolve, rootDir, isEjecting) => {
       'jest-watch-typeahead/testname',
     ],
     resetMocks: true,
+    // Remove this when upgraded to Jest 28
+    resolver: path.join(__dirname, './customJestResolver.js'),
   };
   if (rootDir) {
     config.rootDir = rootDir;

--- a/packages/react-scripts/scripts/utils/customJestResolver.js
+++ b/packages/react-scripts/scripts/utils/customJestResolver.js
@@ -1,0 +1,13 @@
+// Temporary workaround until Jest 28
+const resolver = require('enhanced-resolve').create.sync({
+  conditionNames: ['require', 'node', 'default'],
+  extensions: ['.js', '.jsx', '.json', '.node', '.ts', '.tsx'],
+});
+
+module.exports = function (request, options) {
+  // list global module that must be resolved by defaultResolver here
+  if (['fs', 'http', 'path'].includes(request)) {
+    return options.defaultResolver(request, options);
+  }
+  return resolver(options.basedir, request);
+};


### PR DESCRIPTION
Add custom Jest resolver to support package.json [conditional exports](https://nodejs.org/api/packages.html#conditional-exports) for Jest 27.

This should be removed when upgraded to Jest 28.