### PR TITLE
add istanbul plugin for cypress code coverage

### DIFF
--- a/packages/react-scripts/CHANGELOG.md
+++ b/packages/react-scripts/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Add babel-istanbul-plugin to support collecting test coverage
 
+
 ## 10.0.2
 
 - Fix security issues

--- a/packages/react-scripts/CHANGELOG.md
+++ b/packages/react-scripts/CHANGELOG.md
@@ -1,6 +1,5 @@
 # `backpack-react-scripts` Change Log
 
-
 ## 10.0.3
 
 - Add babel-istanbul-plugin to support collecting test coverage

--- a/packages/react-scripts/CHANGELOG.md
+++ b/packages/react-scripts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `backpack-react-scripts` Change Log
 
+
+## 10.0.3
+
+- Add babel-istanbul-plugin to support collecting test coverage
 ## 10.0.2
 
 - Fix security issues

--- a/packages/react-scripts/CHANGELOG.md
+++ b/packages/react-scripts/CHANGELOG.md
@@ -5,7 +5,6 @@
 
 - Add babel-istanbul-plugin to support collecting test coverage
 
-
 ## 10.0.2
 
 - Fix security issues

--- a/packages/react-scripts/CHANGELOG.md
+++ b/packages/react-scripts/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## 10.0.3
 
 - Add babel-istanbul-plugin to support collecting test coverage
+
 ## 10.0.2
 
 - Fix security issues

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -105,6 +105,11 @@ const hasJsxRuntime = (() => {
   }
 })();
 
+// The istanbul plugin is used to instrument code for coverage information, 
+// pass the config ENABLE_ISTANBUL_PLUGIN=true to enable the plugin. Be cautious this will 
+// result in a large increasement on bundle size, so it should never be enabled in prod build.
+const enableIstanbulPlugin = process.env.ENABLE_ISTANBUL_PLUGIN === 'true';
+
 // This is the production and development configuration.
 // It is focused on developer experience, fast rebuilds, and a minimal bundle.
 module.exports = function (webpackEnv) {
@@ -484,6 +489,13 @@ module.exports = function (webpackEnv) {
                   isEnvDevelopment &&
                     shouldUseReactRefresh &&
                     require.resolve('react-refresh/babel'),
+                  enableIstanbulPlugin && [
+                    require.resolve('babel-plugin-istanbul'),
+                      {
+                        // do not instrument code coverage for tests / storybook files
+                        exclude: ["**/*.test.*", "**/*.stories.*"],
+                      },
+                    ],
                 ].filter(Boolean),
                 // This is a feature of `babel-loader` for webpack (not Babel itself).
                 // It enables caching results in ./node_modules/.cache/babel-loader/

--- a/packages/react-scripts/config/webpack.config.ssr.js
+++ b/packages/react-scripts/config/webpack.config.ssr.js
@@ -75,6 +75,12 @@ const reactRefreshOverlayEntry = require.resolve(
   'react-dev-utils/refreshOverlayInterop'
 );
 
+// The istanbul plugin is not required by ssr. Added it here only to
+// comply with BRS maintenance convention that plugin added to webpack.config.js
+// needs to have an acccordingly config in webpack.config.ssr.js. It can be removed 
+// once such a convention is dropped.
+// const enableIstanbulPlugin = process.env.ENABLE_ISTANBUL_PLUGIN === 'true';
+
 // Some apps do not need the benefits of saving a web request, so not inlining the chunk
 // makes for a smoother build process.
 // const shouldInlineRuntimeChunk = process.env.INLINE_RUNTIME_CHUNK !== 'false';
@@ -524,6 +530,17 @@ module.exports = function (webpackEnv) {
                   isEnvDevelopment &&
                     shouldUseReactRefresh &&
                     require.resolve('react-refresh/babel'),
+                  // The istanbul plugin is not required by ssr. Added it here only to
+                  // comply with BRS maintenance convention that plugin added to webpack.config.js
+                  // needs to have an acccordingly config in webpack.config.ssr.js. It can be removed 
+                  // once such a convention is dropped.
+                  // enableIstanbulPlugin && [
+                  //   require.resolve('babel-plugin-istanbul'),
+                  //     {
+                  //       // do not instrument code coverage for tests / storybook files
+                  //       exclude: ["**/*.test.*", "**/*.stories.*"],
+                  //     },
+                  //   ],
                 ].filter(Boolean),
                 // This is a feature of `babel-loader` for webpack (not Babel itself).
                 // It enables caching results in ./node_modules/.cache/babel-loader/

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -34,6 +34,7 @@
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.6.0",
     "babel-loader": "8.1.0",
+    "babel-plugin-istanbul": "^6.1.1",
     "babel-plugin-named-asset-import": "^0.3.7",
     "babel-preset-react-app": "^10.0.0",
     "bfj": "^7.0.2",


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

This is a PR to add a babel plugin (babel-plugin-istanbul) which is required by [cypress code coverage](https://docs.cypress.io/guides/tooling/code-coverage#Code-coverage-as-a-guide).

The change introduces a flag from env called `ENABLE_ISTANBUL_PLUGIN`, once the flag is presented, webpack will apply [babel-plugin-istanbul](https://github.com/istanbuljs/babel-plugin-istanbul) to the bundling flow. What this plugin does is it will add instrumentation to the origin code, which initially increases the bundle size. Therefore the `ENABLE_ISTANBUL_PLUGIN` is important to prevent adding the instrumentation to a prod build.

 
