### PR TITLE
[NO JIRA]: Add babel config to process the single package Backpack

### DIFF
--- a/packages/react-scripts/backpack-addons/babelIncludePrefixes.js
+++ b/packages/react-scripts/backpack-addons/babelIncludePrefixes.js
@@ -13,6 +13,7 @@ const customModuleRegexes = bpkReactScriptsConfig.babelIncludePrefixes
 const backpackModulesRegex = /node_modules[\\/]bpk-/;
 const saddlebagModulesRegex = /node_modules[\\/]saddlebag-/;
 const scopedBackpackModulesRegex = /node_modules[\\/]@skyscanner[\\/]bpk-/;
+const backpackSinglePackageModulesRegex = /node_modules[\\/]@skyscanner[\\/]backpack-web/;
 
 module.exports = () => {
   return [
@@ -20,6 +21,7 @@ module.exports = () => {
     backpackModulesRegex,
     saddlebagModulesRegex,
     scopedBackpackModulesRegex,
+    backpackSinglePackageModulesRegex,
     ...customModuleRegexes,
   ];
 };

--- a/packages/react-scripts/backpack-addons/cssModules.js
+++ b/packages/react-scripts/backpack-addons/cssModules.js
@@ -9,6 +9,7 @@ const cssModulesEnabled = bpkReactScriptsConfig.cssModules !== false;
 // Backpack / saddlebag node module regexes
 const backpackModulesRegex = /node_modules[\\/]bpk-/;
 const scopedBackpackModulesRegex = /node_modules[\\/]@skyscanner[\\/]bpk-/;
+const backpackSinglePackageModulesRegex = /node_modules[\\/]@skyscanner[\\/]backpack-web/;
 
 const getStyleTestRegexes = (regexType) => {
   // style files regexes, the regex values should keep up to date with webpack.config.js
@@ -21,7 +22,11 @@ const getStyleTestRegexes = (regexType) => {
     case "css":
       return {
         and: [cssRegex, () => !cssModulesEnabled],
-        exclude: [backpackModulesRegex, scopedBackpackModulesRegex],
+        exclude: [
+          backpackModulesRegex,
+          backpackSinglePackageModulesRegex,
+          scopedBackpackModulesRegex,
+        ],
       };
     case "cssModule":
       return [
@@ -30,13 +35,22 @@ const getStyleTestRegexes = (regexType) => {
           and: [cssRegex, () => cssModulesEnabled],
         },
         {
-          and: [cssRegex, backpackModulesRegex, scopedBackpackModulesRegex],
+          and: [
+            cssRegex,
+            backpackModulesRegex,
+            backpackSinglePackageModulesRegex,
+            scopedBackpackModulesRegex,
+          ],
         },
       ];
     case "sass":
       return {
         and: [sassRegex, () => !cssModulesEnabled],
-        exclude: [backpackModulesRegex, scopedBackpackModulesRegex],
+        exclude: [
+          backpackModulesRegex,
+          backpackSinglePackageModulesRegex,
+          scopedBackpackModulesRegex,
+        ],
       };
     case "sassModule":
       return [
@@ -45,7 +59,12 @@ const getStyleTestRegexes = (regexType) => {
           and: [sassRegex, () => cssModulesEnabled],
         },
         {
-          and: [sassRegex, backpackModulesRegex, scopedBackpackModulesRegex],
+          and: [
+            sassRegex,
+            backpackModulesRegex,
+            backpackSinglePackageModulesRegex,
+            scopedBackpackModulesRegex,
+          ],
         },
       ];
     default:
@@ -59,7 +78,7 @@ const getCSSModuleLocalIdent = () => {
             appPackageJson.name
         )
     )
-}
+};
 
 module.exports = {
   getStyleTestRegexes,

--- a/packages/react-scripts/scripts/utils/createJestConfig.js
+++ b/packages/react-scripts/scripts/utils/createJestConfig.js
@@ -18,6 +18,7 @@ const bpkReactScriptsConfig = pkgJson['backpack-react-scripts'] || {};
 const includePrefixes = bpkReactScriptsConfig.babelIncludePrefixes || [];
 includePrefixes.unshift('bpk-');
 includePrefixes.unshift('@skyscanner/bpk-');
+includePrefixes.unshift('@skyscanner/backpack-web');
 includePrefixes.unshift('saddlebag-');
 
 const transformIgnorePattern = `[/\\\\]node_modules[/\\\\](?!${includePrefixes.join(


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

The purpose of this PR is to include config to include Backpack single package as part of the build step, similar to our other Backpack config.

When we were rolling out the single package as part of our automation and speed to adoption we included/updated the following config in projects

```json
 "backpack-react-scripts": {
    "babelIncludePrefixes": [
      "@skyscanner/backpack-web"
    ]
  },
```

As you can see this is not ideal and sustainable given this projects purpose is to include them by default, so anyone using BRS to create new projects shouldn't have to do this themselves. So including the config here.

Once all our usages of the individual Backpack packages are gone and to single package and scoped we can remove/update the original config to be the default (the following line):

`const backpackModulesRegex = /node_modules[\\/]bpk-/;`