### PR TITLE
[Draft] Renaming chunks to invalidate CDN cache

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -210,6 +210,8 @@ module.exports = function (webpackEnv) {
     return loaders;
   };
 
+  const a=1;
+
   return {
     mode: isEnvProduction ? 'production' : isEnvDevelopment && 'development',
     // Stop compilation early in production

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -211,7 +211,7 @@ module.exports = function (webpackEnv) {
   };
 
   const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
-  const appendTextContenthash = bpkReactScriptsConfig.appendTextContenthash || '';
+  const appendTextToContenthash = bpkReactScriptsConfig.appendTextToContenthash || '';
 
   return {
     mode: isEnvProduction ? 'production' : isEnvDevelopment && 'development',
@@ -264,7 +264,7 @@ module.exports = function (webpackEnv) {
       futureEmitAssets: true,
       // There are also additional JS chunk files if you use code splitting.
       chunkFilename: isEnvProduction
-        ? `static/js/[name].[contenthash:8]${appendTextContenthash}.chunk.js`
+        ? `static/js/[name].[contenthash:8]${appendTextToContenthash}.chunk.js`
         : isEnvDevelopment && 'static/js/[name].chunk.js',
       // webpack uses `publicPath` to determine where the app is being served from.
       // It requires a trailing slash, or the file assets will get an incorrect path.

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -210,7 +210,8 @@ module.exports = function (webpackEnv) {
     return loaders;
   };
 
-  const a=1;
+  const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
+  const appendTextContenthash = bpkReactScriptsConfig.appendTextContenthash || '';
 
   return {
     mode: isEnvProduction ? 'production' : isEnvDevelopment && 'development',
@@ -263,7 +264,7 @@ module.exports = function (webpackEnv) {
       futureEmitAssets: true,
       // There are also additional JS chunk files if you use code splitting.
       chunkFilename: isEnvProduction
-        ? 'static/js/[name].[contenthash:8].chunk.js'
+        ? `static/js/[name].[contenthash:8]${appendTextContenthash}.chunk.js`
         : isEnvDevelopment && 'static/js/[name].chunk.js',
       // webpack uses `publicPath` to determine where the app is being served from.
       // It requires a trailing slash, or the file assets will get an incorrect path.


### PR DESCRIPTION
We recently had an [incident](https://gojira.skyscanner.net/browse/INL-1474) in Banana due to CDN having empty chunks in its cache. To mitigate this issue we decided to rename all our chunks and invalidate existing chunks in CDN.

This PR is adding a string from package.json to the chunk name after the content hash. In the future, if we want to rename the chunks again, we will have to update the text in the package.json file.