### PR TITLE
INL-1516: Allow customising of chunkLoadingGlobal for LoadablePlugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,7 @@
     "es6": true
   },
   "parserOptions": {
-    "ecmaVersion": 2018
+    "ecmaVersion": 2020
   },
   "rules": {
     "no-console": "off",

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -105,8 +105,8 @@ const hasJsxRuntime = (() => {
   }
 })();
 
-// The istanbul plugin is used to instrument code for coverage information, 
-// pass the config ENABLE_ISTANBUL_PLUGIN=true to enable the plugin. Be cautious this will 
+// The istanbul plugin is used to instrument code for coverage information,
+// pass the config ENABLE_ISTANBUL_PLUGIN=true to enable the plugin. Be cautious this will
 // result in a large increasement on bundle size, so it should never be enabled in prod build.
 const enableIstanbulPlugin = process.env.ENABLE_ISTANBUL_PLUGIN === 'true';
 
@@ -720,7 +720,9 @@ module.exports = function (webpackEnv) {
       ],
     },
     plugins: [
-      new LoadablePlugin(),
+      new LoadablePlugin({ 
+        chunkLoadingGlobal: appPackageJson['backpack-react-scripts']?.['loadable-components']?.chunkLoadingGlobal,
+      }),
       // Generates an `index.html` file with the <script> injected.
       new HtmlWebpackPlugin(
         Object.assign(


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

Allow customising of chunkLoadingGlobal for LoadablePlugin. 

Docs: https://github.com/gregberge/loadable-components/blob/main/website/src/pages/docs/api-loadable-webpack-plugin.mdx

Information and context: https://github.com/gregberge/loadable-components/pull/701

> We have a case where we're running multiple Webpack runtimes on the same page which both use Loadable. This change adds an optional chunkLoadingGlobal option to LoadablePlugin and loadableReady which namespaces jsonpFunction or chunkLoadingGlobal.
