### PR TITLE
Don't generate package-lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ yarn-error.log*
 /.changelog
 .npm/
 yarn.lock
+package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/react-scripts/CHANGELOG.md
+++ b/packages/react-scripts/CHANGELOG.md
@@ -1,6 +1,6 @@
 # `backpack-react-scripts` Change Log
 
-## 10.1.0
+## 10.2.0
 
 - Disable `loadable` in CSR build
 


### PR DESCRIPTION
As OSS software we don't want to commit lock files to git, this flag
allows us to not generate them