### PR TITLE
[ST-1798] Allow TypeScript 5 as a peer dependency.

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -85,7 +85,7 @@
   },
   "peerDependencies": {
     "react": ">= 16",
-    "typescript": "^3.2.1 || ^4"
+    "typescript": "^3.2.1 || ^4 || ^5"
   },
   "peerDependenciesMeta": {
     "typescript": {


### PR DESCRIPTION
Currently, Backpack React Scripts has TypeScript as a peer dependency, but only allows TypeScript 3 and 4. The latest TypeScript 5 has been released and it would be good to update to this.

This change will not force any of the existing consumers to update, but will allow those who would like to do so at their own risk. This is a very low risk change, since:

TypeScript 5 is backwards compatible.
Any changes or issues will be caught at compile time.