### PR TITLE
[ST-5243] Make splitChunks configurable

### DIFF
--- a/packages/react-scripts/README.md
+++ b/packages/react-scripts/README.md
@@ -30,6 +30,7 @@ npm start
   - `babelIncludePrefixes`: An array of module name prefixes to opt into babel compilation, including local import module, e.g. `"../common"`. Includes `["@skyscanner/bpk-", "bpk-", "saddlebag-"]` by default.
   - `enableAutomaticChunking`: Boolean, opt in to automatic chunking of vendor, common and app code.
   - `vendorsChunkRegex`: String, Regex for picking what goes into the `vendors` chunk. See `cacheGroups` in webpack docs. Dependent on `enableAutomaticChunking` being enabled
+  - `splitChunksConfig`: Object, mapping to the [structure in the webpack docs](https://webpack.js.org/plugins/split-chunks-plugin/#optimizationsplitchunks). Applied only if `enableAutomaticChunking` is false, ignores `vendorsChunkRegex` if defined.
   - `amdExcludes`: Array of module names to exclude from AMD parsing. Incldues `["lodash"]` by default.
   - `externals`: exposing the Webpack config to modify externals, see [docs](https://webpack.js.org/configuration/externals/).
   - `ssrExternals`: Similar to above, but for `ssr.js` only.

--- a/packages/react-scripts/backpack-addons/README.md
+++ b/packages/react-scripts/backpack-addons/README.md
@@ -14,6 +14,7 @@ Our react scripts fork includes a number of custom configuration items in order 
 | **ssrExternals** | The same as above `externals` except used for server side rendering only in **ssr.js** | **{}** |
 | **enableAutomaticChunking** | Opts into automatic chunking of vender, common and app code.<br> When enabled the **splitChunks** plugin creates vender and common chunks which are split and when provided uses the `venderChunkRegex` to specify what is in each chunk.<br> When enabled **runtimeChunk** plugin creates a separate runtime chunk for projects to enable long term caching. | **false** |
 | **vendorsChunkRegex** | Regex for picking what goes into the vendors chunk. Requires enableAutomaticChunking to be enabled.<br> See [cacheGroups](https://webpack.js.org/plugins/split-chunks-plugin/#splitchunkscachegroups) docs for further details. |  |
+| **splitChunksConfig** | Object, mapping to the [structure in the webpack docs](https://webpack.js.org/plugins/split-chunks-plugin/#optimizationsplitchunks).<br> Applied only if `enableAutomaticChunking` is false, ignores `vendorsChunkRegex` if defined. |  |
 | **sassFunctions** | This function encodes svg content into `base64` when there is a `bpk-icon` in the.scss file. |  |
 
 ## How to add new feature

--- a/packages/react-scripts/backpack-addons/splitChunks.js
+++ b/packages/react-scripts/backpack-addons/splitChunks.js
@@ -4,23 +4,85 @@ const paths = require('../config/paths');
 const appPackageJson = require(paths.appPackageJson);
 const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
 
+/**
+ * Defines a webpack splitChunks configuration, optionally based on consumer configuration.
+ * 
+ * For automatic configuration set enableAutomaticChunking and optionally provide a vendorsChunkRegex string, e.g:
+ * 
+ * // package.json
+ * ...
+ * "backpack-react-scripts": {
+ *    ...
+ *    "enableAutomaticChunking": true,
+ *    "vendorsChunkRegex": "...",
+ *    ...
+ * }
+ * ...
+ * 
+ * For custom configuration disable enableAutomaticChunking and provide a configuration object, e.g:
+ * 
+ * // package.json
+ * ...
+ * "backpack-react-scripts": {
+ *    ...
+ *    "enableAutomaticChunking": false,
+ *    "splitChunksConfig": {
+ *       "chunks": "all",
+ *       ...
+ *       "cacheGroups": {
+ *         "vendors": {
+ *           "test": "..."
+ *         },
+ *         "customChunk": {
+ *           "test": "..."
+ *           "priority": 100,
+ *           "chunks": "all",
+ *           "name": "customChunk",
+ *         },
+ *      },
+ *    ...
+ * }
+ * ...
+ * 
+ * References:
+ * https://webpack.js.org/plugins/split-chunks-plugin/#optimizationsplitchunks
+ * https://webpack.js.org/plugins/split-chunks-plugin/#splitchunkscachegroups
+ * https://twitter.com/wSokra/status/969633336732905474
+ * https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
+ */
+
 module.exports = (isEnvDevelopment) => {
-  // Automatically split vendor and commons
-  // https://twitter.com/wSokra/status/969633336732905474
-  // https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
-  return {
-    splitChunks: bpkReactScriptsConfig.enableAutomaticChunking
-    ? {
+
+  let splitChunksConfig =  {}
+
+  // If opted in to automatic chunking, apply default configuration
+  if (bpkReactScriptsConfig.enableAutomaticChunking) {
+    splitChunksConfig = {
       chunks: 'all',
       name: isEnvDevelopment,
-      cacheGroups: bpkReactScriptsConfig.vendorsChunkRegex
-        ? {
-            vendors: {
-              test: new RegExp(bpkReactScriptsConfig.vendorsChunkRegex)
-            },
-          }
-        : {},
-      }
-    : {}
+      cacheGroups: {},
+    };
+    // Apply vendorsChunkRegex if provided
+    if (bpkReactScriptsConfig.vendorsChunkRegex) {
+      splitChunksConfig.cacheGroups = {
+        vendors: {
+          // Regexes are passed as strings in package.json config, but need constructed here.
+          test: new RegExp(bpkReactScriptsConfig.vendorsChunkRegex),
+        },
+      };
+    }
   }
+  // If not opted in to automatic chunking, use custom configuration - if defined.
+  else if(bpkReactScriptsConfig.splitChunksConfig) {
+    // 
+    splitChunksConfig = { ...bpkReactScriptsConfig.splitChunksConfig, name: isEnvDevelopment}
+    // Regexes are passed as strings in package.json config, but need constructed here.
+    for(let cacheGroup of Object.keys(splitChunksConfig.cacheGroups)){
+      splitChunksConfig.cacheGroups[cacheGroup].test = new RegExp(splitChunksConfig.cacheGroups[cacheGroup].test);
+    }
+  }
+
+  return {
+    splitChunks: splitChunksConfig
+  };
 };


### PR DESCRIPTION
👋 


### Context
Internal refs: https://skyscanner.atlassian.net/browse/ST-5243 , https://skyscanner.atlassian.net/wiki/spaces/SEARCHEXPTRIBE/pages/675677007/Unlock+the+Extraction+of+Homepage+from+Bootstrap

Users of BRS are unable to make full use of the flexibility in code splitting provided by [webpack's splitChunks](https://webpack.js.org/plugins/split-chunks-plugin/#optimizationsplitchunks). 

In this PR we allow an Object to be passed from the consumer's package.json, in a similar pattern to the existing vendorsChunkRegex, to the BRS webpack config. Passing via JSON does pose some limitations but it feels like a reasonable step. 

The goal here is to stay both backwards compatible and compatible with Webpack 5.

### Examples

Currently all microsites in Skyscanner use the following config. This still works as before:

```
  "backpack-react-scripts": {
    ...
    "enableAutomaticChunking": true,
    "vendorsChunkRegex": "vendors regex",
  },
```

Here we disable automatic chunking, which prior to this change resolved splitChunks as an empty object, and provide a custom configuration object we can directly inject configuration.

```
  "backpack-react-scripts": {
    ...
    "enableAutomaticChunking": false,
    "splitChunksConfig": {
      "chunks": "all",
      ... any other splitChunk properties
      "cacheGroups": {
        "vendors": {
          "test": "vendors regex"
        },
        "customChunk": {
          "test": "some  custom regex",
          "chunks": "all",
          "name": "customChunk"
        }
      }
    }
  },
```
Note that we now need to pass the vendors regex in the same manner as any other custom cache group.


### MIsc/Qs

Since as mentioned we're going JSON -> JS, we need to find and apply RegExp to test strings. In webpack it's [possible to provide functions instead](https://webpack.js.org/plugins/split-chunks-plugin/#splitchunkscachegroupstest), but with the current approach this isn't easily supported - and currently sees no use within Skyscanner. Most other properties appear to be primitive types so should work without issue.

I've added comments, update the existing READMEs and provided examples inline, happy to add further documentation if required.

