### PR TITLE
[NO JIRA]: Update release CI to set new version numbers

### DIFF
--- a/.github/workflows/fork_cra5.yml
+++ b/.github/workflows/fork_cra5.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Publish NPM package
         run: |
           cd packages/react-scripts
-          npm version prerelease --preid=dev --no-git-tag-version
+          npm version premajor --preid=$BUILD_VERSION-dev --no-git-tag-version
           npm publish --tag alpha
         env:
+          BUILD_VERSION: ${{ github.run_number }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Updates the release setup to increment versions for each merge, this value will be based on the workflow run number to append to the version before publishing