### PR TITLE
[LOOM-1233]: add __unstableEnableBpkStylesChunk config option

### DIFF
--- a/packages/react-scripts/backpack-addons/splitChunks.js
+++ b/packages/react-scripts/backpack-addons/splitChunks.js
@@ -57,6 +57,7 @@ const backpackStylesCacheGroup = {
   chunks: 'all',
   enforce: true,
   test: /[\\/]node_modules[\\/]@skyscanner[\\/]backpack-web[\\/]/,
+  priority: 1
 };
 
 module.exports = () => {

--- a/packages/react-scripts/backpack-addons/splitChunks.js
+++ b/packages/react-scripts/backpack-addons/splitChunks.js
@@ -51,6 +51,14 @@ const paths = require('../config/paths');
 const appPackageJson = require(paths.appPackageJson);
 const bpkReactScriptsConfig = appPackageJson['backpack-react-scripts'] || {};
 
+const backpackStylesCacheGroup = {
+  name: 'bpk-styles',
+  type: 'css/mini-extract',
+  chunks: 'all',
+  enforce: true,
+  test: /[\\/]node_modules[\\/]@skyscanner[\\/]backpack-web[\\/]/,
+};
+
 module.exports = () => {
   let splitChunksConfig = {};
 
@@ -83,6 +91,13 @@ module.exports = () => {
         );
       }
     }
+  }
+
+  if (bpkReactScriptsConfig.__unstableEnableBpkStylesChunk) {
+    if (!splitChunksConfig.cacheGroups) {
+      splitChunksConfig.cacheGroups = {};
+    }
+    splitChunksConfig.cacheGroups.bpkStyles = backpackStylesCacheGroup;
   }
 
   return {


### PR DESCRIPTION
Allow consumers configuration to turn on and off a new cacheGroup within the splitchunks addon to allow all of Bpk stylesheets to be grouped together. 