### PR TITLE
Change span element to self-closing tag

### DIFF
--- a/test/fixtures/webpack-message-formatting/src/AppBabel.js
+++ b/test/fixtures/webpack-message-formatting/src/AppBabel.js
@@ -4,7 +4,7 @@ class App extends Component {
   render() {
     return (
       <div>
-        <span>
+        <span/>
       </div>
     );
   }

--- a/test/fixtures/webpack-message-formatting/src/AppBabel.js
+++ b/test/fixtures/webpack-message-formatting/src/AppBabel.js
@@ -4,7 +4,7 @@ class App extends Component {
   render() {
     return (
       <div>
-        <span/>
+        <span></span>
       </div>
     );
   }


### PR DESCRIPTION
Could not process some files due to syntax errors
[View file](https://github.com/Skyscanner/backpack-react-scripts/blob/main/test/fixtures/webpack-message-formatting/src/AppBabel.js#L8)
A parse error occurred: Unterminated JSX contents. Check the syntax of the file. If the file is invalid, correct the error or [exclude](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning) the file from analysis.