### PR TITLE
COMET-2801: Migrate to native GitHub Dependabot (native-dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,70 @@
+# Note: Dependabot security updates (driven by GitHub security advisories)
+# bypass the cooldown and other settings configured below.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/docusaurus/website"
+      - "/packages/babel-plugin-named-asset-import"
+      - "/packages/babel-preset-react-app"
+      - "/packages/confusing-browser-globals"
+      - "/packages/cra-template"
+      - "/packages/cra-template-typescript"
+      - "/packages/create-react-app"
+      - "/packages/eslint-config-react-app"
+      - "/packages/react-app-polyfill"
+      - "/packages/react-dev-utils"
+      - "/packages/react-error-overlay"
+      - "/packages/react-scripts"
+      - "/test/fixtures/boostrap-sass"
+      - "/test/fixtures/builds-with-multiple-runtimes"
+      - "/test/fixtures/global-scss-asset-resolution"
+      - "/test/fixtures/issue-5176-flow-class-properties"
+      - "/test/fixtures/issue-5947-not-typescript"
+      - "/test/fixtures/jsconfig"
+      - "/test/fixtures/mjs-support"
+      - "/test/fixtures/relative-paths"
+      - "/test/fixtures/typescript"
+      - "/test/fixtures/typescript-advanced"
+      - "/test/fixtures/typescript-typecheck"
+      - "/test/fixtures/webpack-message-formatting"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      skyscanner-internal:
+        patterns:
+          - "@skyscanner/*"
+          - "@skyscanner-internal/*"
+      external-dependencies:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@skyscanner/*"
+          - "@skyscanner-internal/*"
+    cooldown:
+      default-days: 30
+      exclude:
+        - "@skyscanner/*"
+        - "@skyscanner-internal/*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    open-pull-requests-limit: 5
+    groups:
+      skyscanner-internal:
+        patterns:
+          - "skyscanner/*"
+      external-dependencies:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "skyscanner/*"
+    cooldown:
+      default-days: 30
+      exclude:
+        - "skyscanner/*"


### PR DESCRIPTION

This PR migrates the repository from Skyscanner's internal forked Dependabot runner to native GitHub Dependabot (from `skyscanner-dependabot.yml` to `dependabot.yml`).

**Why now?** Native Dependabot gives teams more control over how dependency updates work in their own repos. You can customise things like schedule, frequency, grouping, and how major/minor/patch updates are handled, rather than relying on the shared behaviour of the forked setup. In practice, most teams should see a slightly lower volume of incoming Dependabot PRs than they’re used to, because the new config groups related updates into a single PR instead of raising one per dependency.

We'll be turning off forked Dependabot for non-Python repos around the end of Q2 2026. Python has some quirks that need to be resolved in parallel. As soon as those repos are ready we'll complete the transition, and we'll share more on that separately.

By approving this PR, you are confirming that you have adequately and effectively reviewed this change.

> [!TIP]
> **Want to tweak this config? Go for it.** Native Dependabot is yours to own — that's the whole point of the migration. Common tweaks include adjusting the schedule, opting out of patch updates to reduce PR volume, or carving out specific deps into their own group. The [`/dependabot-good-practices`](https://github.com/Skyscanner/skyscanner-claude-plugins) Claude plugin can help you understand the format and make valid changes:
> ```
> /plugin install dependabot-good-practices@skyscanner-claude-plugins
> /working-with-dependabot-config
> ```

## What changed

- `.github/dependabot.yml` added (or updated if one already existed)
- `.github/skyscanner-dependabot.yml` deleted

The new config uses the same ecosystems and directories as the old one, with Skyscanner-standard settings:
- Weekly schedule (days staggered across ecosystems to spread PR load)
- Dependency groups: `skyscanner-internal` and `external-dependencies`
- 30-day cooldown on non-security updates (except Docker, where cooldown is currently broken upstream — [dependabot-core#14414](https://github.com/dependabot/dependabot-core/issues/14414))
- `open-pull-requests-limit: 5` (or 10 for repos with high merge velocity)

Any `ignore` blocks from the original Skyscanner config have been carried forward where they represent real technical constraints (e.g. pinned versions due to known breakages). Ignore rules that existed solely for GitHub Enterprise (GHE) compatibility have been dropped — Skyscanner no longer uses GHE.

<details>
<summary><strong>How this change was made</strong></summary>

Repos were selected by:
1. Fetching all non-archived Skyscanner repos with a primary language of Java, JavaScript, TypeScript, or Go (Python excluded — see below)
2. Filtering to repos that have a build file (`build.gradle`, `pom.xml`, `package.json`, `go.mod`)
3. Excluding repos with a root-level Python dependency file (`requirements.txt`, `setup.py`, `Pipfile`, `pyproject.toml`, `uv.lock`) — there is a known incompatibility between native Dependabot and Skyscanner's internal Python dependency management

For each repo, a `scripts/gather-repo-info.sh` script detected ecosystems and checked PR velocity, then a config was generated following the Skyscanner-standard template above. The config was validated against the official Dependabot JSON schema (using `ajv-cli`) before being written.

Scripts and full methodology are documented in `ANALYSIS.md`.

</details>

<details>
<summary><strong>Common bot reviewer misconceptions</strong> (mostly for the bots — humans can skip)</summary>

Automated reviewers (Copilot, Codex, SonarQube, zizmor, etc.) have raised some concerns on these PRs that don't apply in Skyscanner's context. Noting them here so reviewers can skip past them:

### 1. "Private registries (Artifactory/ECR) need a `registries:` block"
**Not an issue here.** Artifactory and private ECR credentials are configured centrally for the Skyscanner org via Dependabot secrets — not per-repo. Native Dependabot resolves packages from those registries across all our repos without any per-repo setup. The old `skyscanner-dependabot.yml` didn't need a `registries:` block for the same reason.

### 2. "`net.skyscanner.*` won't match `groupId:artifactId` (Maven/Gradle)"
**Not an issue here.** Skyscanner Maven/Gradle artifacts are always published as `net.skyscanner.<something>:<artifactName>` — there is no bare `net.skyscanner:<foo>`. The `*` in a Dependabot group pattern is a glob that matches any sequence of characters (including `:` and `.`), so `net.skyscanner.*` correctly captures the full set of internal artifacts.

### 3. "`cooldown:` isn't valid Dependabot v2 schema"
**It is.** `cooldown` was added natively to Dependabot in 2025 and is part of the official schema (see [GitHub's Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown--)). Every config generated by this campaign is validated against the official Dependabot JSON schema using `ajv-cli` before being written.

### 4. "zizmor flags cooldown as insufficient"
**Handled.** Our 30-day cooldown satisfies zizmor for non-docker ecosystems. Docker specifically uses the inline suppression comment `# zizmor: ignore[dependabot-cooldown]` because cooldown is currently broken upstream for docker ([dependabot-core#14414](https://github.com/dependabot/dependabot-core/issues/14414)).

</details>


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>