### PR TITLE
[GATE-1102]: Fix webpackDevServer config for webpack-dev-server v5 compatibility

### DIFF
--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -114,7 +114,6 @@ module.exports = function (proxy, allowedHost) {
       disableDotRule: true,
       index: paths.publicUrlOrPath,
     },
-    // `proxy` is run between `before` and `after` `webpack-dev-server` hooks
     proxy,
     // webpack-dev-server v5 replaced onBeforeSetupMiddleware/onAfterSetupMiddleware with setupMiddlewares.
     setupMiddlewares(middlewares, devServer) {

--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -99,7 +99,14 @@ module.exports = function (proxy, allowedHost) {
       publicPath: paths.publicUrlOrPath.slice(0, -1),
     },
 
-    https: getHttpsConfig(),
+    // webpack-dev-server v5 replaced the top-level `https` option with `server`.
+    // getHttpsConfig() returns false, true, or { cert, key }.
+    server: (() => {
+      const httpsConfig = getHttpsConfig();
+      if (!httpsConfig) return 'http';
+      if (httpsConfig === true) return 'https';
+      return { type: 'https', options: httpsConfig };
+    })(),
     host,
     historyApiFallback: {
       // Paths with dots should still use the history fallback.
@@ -109,27 +116,29 @@ module.exports = function (proxy, allowedHost) {
     },
     // `proxy` is run between `before` and `after` `webpack-dev-server` hooks
     proxy,
-    onBeforeSetupMiddleware(devServer) {
+    // webpack-dev-server v5 replaced onBeforeSetupMiddleware/onAfterSetupMiddleware with setupMiddlewares.
+    setupMiddlewares(middlewares, devServer) {
       // Keep `evalSourceMapMiddleware`
       // middlewares before `redirectServedPath` otherwise will not have any effect
       // This lets us fetch source contents from webpack for the error overlay
-      devServer.app.use(evalSourceMapMiddleware(devServer));
+      middlewares.unshift(evalSourceMapMiddleware(devServer));
 
       if (fs.existsSync(paths.proxySetup)) {
         // This registers user provided middleware for proxy reasons
         require(paths.proxySetup)(devServer.app);
       }
-    },
-    onAfterSetupMiddleware(devServer) {
+
       // Redirect to `PUBLIC_URL` or `homepage` from `package.json` if url not match
-      devServer.app.use(redirectServedPath(paths.publicUrlOrPath));
+      middlewares.push(redirectServedPath(paths.publicUrlOrPath));
 
       // This service worker file is effectively a 'no-op' that will reset any
       // previous service worker registered for the same host:port combination.
       // We do this in development to avoid hitting the production cache if
       // it used the same host and port.
       // https://github.com/facebook/create-react-app/issues/2272#issuecomment-302832432
-      devServer.app.use(noopServiceWorkerMiddleware(paths.publicUrlOrPath));
+      middlewares.push(noopServiceWorkerMiddleware(paths.publicUrlOrPath));
+
+      return middlewares;
     },
   };
 };


### PR DESCRIPTION
## Summary

- Replaces the removed top-level `https` option with the v5 `server` option, mapping `getHttpsConfig()` output to the correct format (`'http'`, `'https'`, or `{ type: 'https', options: { cert, key } }`)
- Replaces the removed `onBeforeSetupMiddleware`/`onAfterSetupMiddleware` hooks with the v5 `setupMiddlewares` API

## Context

`backpack-react-scripts@11.2.3` pulled in `webpack-dev-server@^5.2.2` but `webpackDevServer.config.js` still used v4 APIs, causing this schema validation error on startup in profile, login and subscription-microsite:

```
options has an unknown property 'https'. These properties are valid:
object { allowedHosts?, bonjour?, client?, compress?, devMiddleware?, headers?, historyApiFallback?, host?, hot?, ipc?, liveReload?, onListening?, open?, port?, proxy?, server?, app?, setupExitSignals?, setupMiddlewares?, static?, watchFiles?, webSocketServer? }
```

Those consumers worked around it by either reverting to `11.2.2` (profile) or overriding wds back to v4 (login, subscription-microsite). Once this is released as `11.2.4` they can bump to the fixed version and remove their workarounds.

Fixes [GATE-1102](https://skyscanner.atlassian.net/browse/GATE-1102)

**TESTING**:

Tested locally by packing the patched version with `npm pack` and installing the tarball directly into `profile/client`. Ran client dev server and it started successfully with no schema validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[GATE-1102]: https://skyscanner.atlassian.net/browse/GATE-1102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ